### PR TITLE
Adds latest write-good-rule dependency

### DIFF
--- a/.automation/test/natural_language/README.md
+++ b/.automation/test/natural_language/README.md
@@ -4,17 +4,17 @@ This folder holds the test cases for **natural language**.
 
 ## Additional Docs
 
-No Additional information is needed for this test case.
+This test case does not need any extra information.
 
 ## Good Test Cases
 
-The test cases denoted: `LANGUAGE_good_FILE.EXTENSION` are all valid, and should pass successfully when linted.
+The test cases denoted: `LANGUAGE_good_FILE.EXTENSION` are all valid, and should pass when linted.
 
-- **Note:** They are linted utilizing the default linter rules.
+- **Note:** They feed the linter utilizing the default rules.
 
 ## Bad Test Cases
 
 The test cases denoted: `LANGUAGE_bad_FILE.EXTENSION` are **NOT** valid, and should trigger errors when linted.
 
-- **Note:** They are linted utilizing the default linter rules.
-{"mode":"full","isActive":false}
+- **Note:** They feed the linter utilizing the default rules.
+  {"mode":"full","isActive":false}

--- a/.automation/test/natural_language/natural_language_bad_01.md
+++ b/.automation/test/natural_language/natural_language_bad_01.md
@@ -1,2 +1,2 @@
-My **Javascript** is good
-Write change logs about source-maps
+My **JavaScript** is good
+Write changelogs about source maps

--- a/.automation/test/natural_language/natural_language_bad_02.md
+++ b/.automation/test/natural_language/natural_language_bad_02.md
@@ -1,0 +1,1 @@
+My **javascript** is good when is linted

--- a/.automation/test/natural_language/natural_language_bad_02.md
+++ b/.automation/test/natural_language/natural_language_bad_02.md
@@ -1,0 +1,1 @@
+I don't like to using passive tense but some times, it is needed.

--- a/.automation/test/natural_language/natural_language_bad_02.md
+++ b/.automation/test/natural_language/natural_language_bad_02.md
@@ -1,1 +1,0 @@
-I don't like to using passive tense but some times, it is needed.

--- a/.automation/test/natural_language/natural_language_good_02.md
+++ b/.automation/test/natural_language/natural_language_good_02.md
@@ -1,0 +1,1 @@
+I don't like to using passive tense so, I wont use it.

--- a/.automation/test/natural_language/natural_language_good_02.md
+++ b/.automation/test/natural_language/natural_language_good_02.md
@@ -1,0 +1,1 @@
+My **JavaScript** is good when linted

--- a/.automation/test/natural_language/natural_language_good_02.md
+++ b/.automation/test/natural_language/natural_language_good_02.md
@@ -1,1 +1,0 @@
-I don't like to using passive tense so, I wont use it.

--- a/.github/linters/.textlintrc
+++ b/.github/linters/.textlintrc
@@ -3,6 +3,7 @@
     "comments": true
   },
   "rules": {
-    "terminology": true
+    "terminology": true,
+    "write-good": true
   }
 }

--- a/dependencies/package-lock.json
+++ b/dependencies/package-lock.json
@@ -54,6 +54,7 @@
         "textlint-filter-rule-allowlist": "^4.0.0",
         "textlint-filter-rule-comments": "^1.2.2",
         "textlint-rule-terminology": "^3.0.4",
+        "textlint-rule-write-good": "^2.0.0",
         "ts-standard": "^12.0.2",
         "typescript": "^5.0.4"
       }
@@ -2263,6 +2264,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adverb-where": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/adverb-where/-/adverb-where-0.2.5.tgz",
+      "integrity": "sha512-JiQe2U1UR8l10jPrXv/PmlDhOLZpsxqjvTp+k6Dm5wYDUULdMZytDRmovkXU8X6V9o0sg0FBdetv3VXHAZZK5Q==",
+      "engines": {
+        "node": ">=6",
+        "npm": ">=5"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -3481,6 +3491,11 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/e-prime": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/e-prime/-/e-prime-0.10.4.tgz",
+      "integrity": "sha512-tzBmM2mFSnAq5BuxPSyin6qXb3yMe1wufJN7L7ZPcEWS5S+jI2dhKQEoqHVEcSMMXo/j5lcWpX5jzA6wLSmX6w=="
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.284",
@@ -7348,6 +7363,21 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/no-cliches": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/no-cliches/-/no-cliches-0.3.4.tgz",
+      "integrity": "sha512-oUqnng1vhKLaA4GR+OzVbLuZZ7OOguKCtMHxHMiyP8+9mXidKfoCyc030LbAyNI3xcgCHHyitK3Q8wP+w6DwVQ==",
+      "engines": {
+        "node": ">=6",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "eslint-plugin-import": "^2.22.1",
+        "eslint-plugin-jsx-a11y": "^6.4.1",
+        "eslint-plugin-react": "^7.21.5",
+        "eslint-plugin-react-hooks": "^4.0.0"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -7868,6 +7898,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/passive-voice": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/passive-voice/-/passive-voice-0.1.0.tgz",
+      "integrity": "sha512-Pj9iwzXw4bKEtdugGYm92jT4tnsj+xrTSkHFEM4bn6fefqbFdZi49tZMmGIZ91aIQTyFtMUww7O2qYaZKAsDag=="
     },
     "node_modules/path-exists": {
       "version": "3.0.0",
@@ -9977,6 +10012,18 @@
       "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
       "integrity": "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA=="
     },
+    "node_modules/textlint-rule-write-good": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-write-good/-/textlint-rule-write-good-2.0.0.tgz",
+      "integrity": "sha512-yvOJavJD+PgyUzvsoLDDzDtgCVBva/HNhEvsFnYVugrWz0qy2hr+/4B4wkzjro4wfPbwz20GQe5h13N4DeUEeA==",
+      "dependencies": {
+        "textlint-rule-helper": "^2.2.0",
+        "write-good": "^1.0.8"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/textlint/node_modules/file-entry-cache": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
@@ -10270,6 +10317,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
       "integrity": "sha1-zCAOqyYT9BZtJ/+a/HylbUnfbrQ="
+    },
+    "node_modules/too-wordy": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/too-wordy/-/too-wordy-0.3.4.tgz",
+      "integrity": "sha512-EU+UA4zHc06TkVQaravNNVdqX763/ENTIOKiKlqSJ6WKCPwLxHjvY3d0uEJYaq92iojyHPwD2iaYbZKjdw3icA==",
+      "engines": {
+        "node": ">=6",
+        "npm": ">=5"
+      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -10880,6 +10936,11 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/weasel-words": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/weasel-words/-/weasel-words-0.1.1.tgz",
+      "integrity": "sha512-rWkTAGqs4TN6qreS06+irmFUMrQVx5KoFjD8CxMHUsAwmxw/upDcfleaEYOLsonUbornahg+VJ9xrWxp4udyJA=="
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
@@ -11034,6 +11095,33 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/write-good": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/write-good/-/write-good-1.0.8.tgz",
+      "integrity": "sha512-P1Ct7+DNrOcr2JAxDZ3Q5i5sx2LSveu7iLaoUL0A+YiG0GKf0l5+9j3rwMeyh6JeTL1+HfQV1rnwEvzhNIvpFw==",
+      "dependencies": {
+        "adverb-where": "^0.2.2",
+        "commander": "^2.19.0",
+        "e-prime": "^0.10.4",
+        "no-cliches": "^0.3.0",
+        "passive-voice": "^0.1.0",
+        "too-wordy": "^0.3.1",
+        "weasel-words": "^0.1.1"
+      },
+      "bin": {
+        "write-good": "bin/write-good.js",
+        "writegood": "bin/write-good.js"
+      },
+      "engines": {
+        "node": ">=6",
+        "npm": ">=5"
+      }
+    },
+    "node_modules/write-good/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/xdg-basedir": {
       "version": "4.0.0",
@@ -12930,6 +13018,11 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
     },
+    "adverb-where": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/adverb-where/-/adverb-where-0.2.5.tgz",
+      "integrity": "sha512-JiQe2U1UR8l10jPrXv/PmlDhOLZpsxqjvTp+k6Dm5wYDUULdMZytDRmovkXU8X6V9o0sg0FBdetv3VXHAZZK5Q=="
+    },
     "agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -13823,6 +13916,11 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "e-prime": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/e-prime/-/e-prime-0.10.4.tgz",
+      "integrity": "sha512-tzBmM2mFSnAq5BuxPSyin6qXb3yMe1wufJN7L7ZPcEWS5S+jI2dhKQEoqHVEcSMMXo/j5lcWpX5jzA6wLSmX6w=="
     },
     "electron-to-chromium": {
       "version": "1.4.284",
@@ -16620,6 +16718,12 @@
         "tslib": "^2.0.3"
       }
     },
+    "no-cliches": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/no-cliches/-/no-cliches-0.3.4.tgz",
+      "integrity": "sha512-oUqnng1vhKLaA4GR+OzVbLuZZ7OOguKCtMHxHMiyP8+9mXidKfoCyc030LbAyNI3xcgCHHyitK3Q8wP+w6DwVQ==",
+      "requires": {}
+    },
     "node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -17000,6 +17104,11 @@
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
       }
+    },
+    "passive-voice": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/passive-voice/-/passive-voice-0.1.0.tgz",
+      "integrity": "sha512-Pj9iwzXw4bKEtdugGYm92jT4tnsj+xrTSkHFEM4bn6fefqbFdZi49tZMmGIZ91aIQTyFtMUww7O2qYaZKAsDag=="
     },
     "path-exists": {
       "version": "3.0.0",
@@ -18743,6 +18852,15 @@
         "textlint-rule-helper": "^2.1.1"
       }
     },
+    "textlint-rule-write-good": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-write-good/-/textlint-rule-write-good-2.0.0.tgz",
+      "integrity": "sha512-yvOJavJD+PgyUzvsoLDDzDtgCVBva/HNhEvsFnYVugrWz0qy2hr+/4B4wkzjro4wfPbwz20GQe5h13N4DeUEeA==",
+      "requires": {
+        "textlint-rule-helper": "^2.2.0",
+        "write-good": "^1.0.8"
+      }
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -18776,6 +18894,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
       "integrity": "sha1-zCAOqyYT9BZtJ/+a/HylbUnfbrQ="
+    },
+    "too-wordy": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/too-wordy/-/too-wordy-0.3.4.tgz",
+      "integrity": "sha512-EU+UA4zHc06TkVQaravNNVdqX763/ENTIOKiKlqSJ6WKCPwLxHjvY3d0uEJYaq92iojyHPwD2iaYbZKjdw3icA=="
     },
     "tr46": {
       "version": "0.0.3",
@@ -19198,6 +19321,11 @@
         }
       }
     },
+    "weasel-words": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/weasel-words/-/weasel-words-0.1.1.tgz",
+      "integrity": "sha512-rWkTAGqs4TN6qreS06+irmFUMrQVx5KoFjD8CxMHUsAwmxw/upDcfleaEYOLsonUbornahg+VJ9xrWxp4udyJA=="
+    },
     "web-streams-polyfill": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
@@ -19312,6 +19440,27 @@
       "requires": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
+      }
+    },
+    "write-good": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/write-good/-/write-good-1.0.8.tgz",
+      "integrity": "sha512-P1Ct7+DNrOcr2JAxDZ3Q5i5sx2LSveu7iLaoUL0A+YiG0GKf0l5+9j3rwMeyh6JeTL1+HfQV1rnwEvzhNIvpFw==",
+      "requires": {
+        "adverb-where": "^0.2.2",
+        "commander": "^2.19.0",
+        "e-prime": "^0.10.4",
+        "no-cliches": "^0.3.0",
+        "passive-voice": "^0.1.0",
+        "too-wordy": "^0.3.1",
+        "weasel-words": "^0.1.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
       }
     },
     "xdg-basedir": {

--- a/dependencies/package.json
+++ b/dependencies/package.json
@@ -49,6 +49,7 @@
     "textlint-filter-rule-allowlist": "^4.0.0",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-terminology": "^3.0.4",
+    "textlint-rule-write-good": "^2.0.0",
     "ts-standard": "^12.0.2",
     "typescript": "^5.0.4"
   }


### PR DESCRIPTION
Related to https://github.com/github/super-linter/pull/3554. 
**Summary**: Adds texlint write good rule so it can be used in a `.textlintrc`.

## Proposed Changes

* add [textlint-rule-write-good](https://www.npmjs.com/package/textlint-rule-write-good)