### PR TITLE
fix: Correct typo in env. var. name

### DIFF
--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -101,7 +101,7 @@ function BuildFileList() {
     ##############################
     # Check the shell for errors #
     ##############################
-    if [ ${ERROR_CODE} -ne 0 ] && [ "${LOCAL_UPDATDES}" == "false" ]; then
+    if [ ${ERROR_CODE} -ne 0 ] && [ "${LOCAL_UPDATES}" == "false" ]; then
       # Error
       info "Failed to switch to ${DEFAULT_BRANCH} branch to get files changed!"
       fatal "[${SWITCH_CMD}]"


### PR DESCRIPTION
_This is my first time doing a pull request maybe ever, so please forgive me if I muss up something here (and give feedback, I can't improve without that)_

At work we use super-linter all over, and recently someone noticed that in the middle of a run there's a strange error that _seems_ to be fatal, and yet the code continues to run after it:

```
found item:[RUST_CLIPPY], removing linter...
fatal: unable to access 'https://github.com/MyCompany/OurRepo': Could not resolve host: github.com
2023-04-11 21:25:53 [NOTICE]   All file(s) linted successfully with no errors detected
```

As a first step, I changed logging to `TRACE`, giving me more information I could use to pinpoint where the error was:

```
2023-04-28 17:16:21 [DEBUG]   Running git config for safe dirs
2023-04-28 17:16:21 [DEBUG]   ----------------------------------------------
2023-04-28 17:16:21 [DEBUG]   Pulling in code history and branches...
fatal: unable to access 'https://github.com/MyCompany/OurRepo/': Could not resolve host: github.com
2023-04-28 17:16:21 [DEBUG]   ----------------------------------------------
2023-04-28 17:16:21 [DEBUG]   Generating Diff with:[git -C /github/workspace diff --name-only master...bc76ee282c057ab620223a77e89afa35b64cbf1f --diff-filter=d | xargs -I % sh -c 'echo "/github/workspace/%"' 2>&1]
2023-04-28 17:16:21 [DEBUG]   RAW_FILE_ARRAY contents: /github/workspace/.github/workflows/linter-terraform.yml
```

Which let me narrow things down to the following slice of code:
https://github.com/super-linter/super-linter/blob/2f0d37cf16b59b73e00797fd6292d594e7a39c7f/lib/functions/buildFileList.sh#L91-L108

and so caught my attention that the second part of the logical test is `"${LOCAL_UPDATDES}" == "false"`, while elsewhere the variable is referenced as:

https://github.com/super-linter/super-linter/blob/2f0d37cf16b59b73e00797fd6292d594e7a39c7f/lib/linter.sh#L139

Oops!


<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

_^Meta: Oops, should I open an issue and then make a PR or is it fine to just make this PR?_

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Correct name of environment variable to match other usages of it in the code base.

## Readiness Checklist

### Author/Contributor
- [x] ~If documentation is needed for this change, has that been included in this pull request~ _No documentation changes needed (I think)_

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
