### PR TITLE
Use non-deprecated defaults for R-based linter

### DIFF
--- a/TEMPLATES/.lintr
+++ b/TEMPLATES/.lintr
@@ -1,1 +1,1 @@
-linters: with_defaults(object_usage_linter = NULL)
+linters: linters_with_defaults(object_usage_linter = NULL)


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- Describe what the changes are -->

## Proposed Changes

The function `with_defaults` was deprecated in lintr version 3.0.0, which is currently installed on the super-linter image.
Use `linters_with_defaults` or `modify_defaults` instead.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request
> No documentation changes are needed.

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
