### PR TITLE
Moves notice under h1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-**NOTICE**: If your use of the super-linter action failed around April 26th, 2023, we changed the organization name from `github` to `super-linter` so you will need to update your references to this action from `github/super-linter` to `super-linter/super-linter`.
-<hr>
 # Super-Linter
+
+**NOTICE**: If your use of the super-linter action failed around April 26th, 2023, we changed the organization name from `github` to `super-linter` so you will need to update your references to this action from `github/super-linter` to `super-linter/super-linter`.
 
 This repository is for the **GitHub Action** to run a **Super-Linter**.
 It is a simple combination of various linters, written in `bash`, to help validate your source code.


### PR DESCRIPTION
One of the linter rules run against this repo requires the README start with an h1. By inserting this notice above in #4152, the linter rule has been broken. This change fixes it.

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Bring org notice under the h1 of the README file

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
