### PR TITLE
Fixes bare URL in Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at opensource@github.com. All
+reported by contacting the project team at <opensource@github.com>. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
An update to markdownlint in #4158 has highlighted that the current file breaks one of the rules, namely: https://github.com/updownpress/markdown-lint/blob/master/rules/034-no-bare-urls.md

This commit resolves the issue by adding angle brackets around the URL.

<!-- Describe what the changes are -->

## Proposed Changes

1. Add angle brackets around bare URL in code of conduct.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
