### PR TITLE
git check-ignore is run on every file

### DIFF
--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -304,7 +304,7 @@ function BuildFileList() {
     ###################################################
     # Filter files if FILTER_REGEX_EXCLUDE is not set #
     ###################################################
-    if git check-ignore "$FILE" && [ "${IGNORE_GITIGNORED_FILES}" == "true" ]; then
+    if [ "${IGNORE_GITIGNORED_FILES}" == "true" ] && git check-ignore "$FILE"; then
       debug "${FILE} is ignored by Git. Skipping ${FILE}"
       continue
     fi


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. By checking that `IGNORE_GITIGNORED_FILES` is set to true before running `git check-ignore "$FILE"` we can prevent the git check-ignore command from being run unnecessarily.   This has the secondary benefit a not causing the following error message to be printed once per linted file outside of a git project: `fatal not a git repository (or any of the parent directories) ...`

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
