### PR TITLE
Improve GITHUB_DOMAIN/GITHUB_SERVER_URL default value handling

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -77,6 +77,15 @@ fi
 # Remove trailing slash if present
 GITHUB_API_URL="${GITHUB_API_URL%/}"
 
+# GitHub server url
+if [ -n "$GITHUB_DOMAIN" ]; then
+  GITHUB_SERVER_URL="${GITHUB_DOMAIN}"
+elif [ -z "$GITHUB_SERVER_URL" ]; then
+  GITHUB_SERVER_URL="https://github.com"
+fi
+# Extract domain name from URL
+GITHUB_SERVER_URL=$(echo "$GITHUB_SERVER_URL" | cut -d '/' -f 3)
+
 # Default Vars
 DEFAULT_RULES_LOCATION='/action/lib/.automation'          # Default rules files location
 LINTER_RULES_PATH="${LINTER_RULES_PATH:-.github/linters}" # Linter rules directory
@@ -654,7 +663,6 @@ CallStatusAPI() {
 
     debug "URL: ${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}"
 
-    GITHUB_DOMAIN=$(echo "$GITHUB_DOMAIN" | cut -d '/' -f 3)
 
     ##############################################
     # Call the status API to create status check #
@@ -666,7 +674,7 @@ CallStatusAPI() {
         -H "authorization: Bearer ${GITHUB_TOKEN}" \
         -H 'content-type: application/json' \
         -d "{ \"state\": \"${STATUS}\",
-        \"target_url\": \"https://${GITHUB_DOMAIN:-github.com}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}\",
+        \"target_url\": \"https://${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}\",
         \"description\": \"${MESSAGE}\", \"context\": \"--> Linted: ${LANGUAGE}\"
       }" 2>&1
     )

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -663,7 +663,6 @@ CallStatusAPI() {
 
     debug "URL: ${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}"
 
-
     ##############################################
     # Call the status API to create status check #
     ##############################################


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

Follow up to #4362
Inspired by #2031

## Proposed Changes

1. If `GITHUB_DOMAIN` exists, use its value as GitHub domain
2. If `GITHUB_DOMAIN` does not exist, but `GITHUB_SERVER_URL` is already set, use its value as GitHub domain
3. If neither `GITHUB_DOMAIN` nor `GITHUB_SERVER_URL` is set, use `https://github.com` as GitHub domain

## Readiness Checklist

You can test the change with following configuration: 
- Update the docker image in the `action.yml` to `ghcr.io/shegox/super-linter:github-domains-2` in your testing fork
- Use it with `[your-fork]/github-super-linter@[your-branch]`

Testing with following settings in GitHub Actions:
1. GITHUB_DOMAIN=`https://github.enterprise.com`  ✅ 
2. GITHUB_DOMAIN=`github.enterprise.com`  ✅ 
3. GITHUB_DOMAIN unset ✅ 

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`

//cc @zkoppert