### PR TITLE
Use calculated major version instead of hardcoded v5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
           SEMVER_VERSION=${RELEASE_VERSION#v}
           SEMVER_MAJOR_VERSION=${SEMVER_VERSION%%.*}
           SEMVER_MAJOR_VERSION_WITH_PREFIX=v${SEMVER_MAJOR_VERSION}
-          
+
           {
             echo "RELEASE_VERSION=${RELEASE_VERSION}"
             echo "SEMVER_VERSION=${SEMVER_VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           src: ghcr.io/super-linter/super-linter:${{ matrix.images.prefix }}latest
           dst: |
-            ghcr.io/super-linter/super-linter:${{ matrix.images.prefix }}v5
+            ghcr.io/super-linter/super-linter:${{ matrix.images.prefix }}${{ env.SEMVER_MAJOR_VERSION_WITH_PREFIX }}
             ghcr.io/super-linter/super-linter:${{ matrix.images.prefix }}${{ env.RELEASE_VERSION }}
 
       - name: Checkout Code


### PR DESCRIPTION
fixes #4419

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Use calculated major version instead of hardcoded v5

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
