### PR TITLE
Handle tflint deprecations

### DIFF
--- a/lib/functions/worker.sh
+++ b/lib/functions/worker.sh
@@ -284,7 +284,7 @@ function LintCodebase() {
 
         LINT_CMD=$(
           cd "${DIR_NAME}" || exit
-          ${LINTER_COMMAND} "${FILE_NAME}" 2>&1
+          ${LINTER_COMMAND} --filter="${FILE_NAME}" 2>&1
         )
       else
         ################################


### PR DESCRIPTION
Solve the deprecations introduced in tflint, which are getting removed in v0.47.0.

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Unblock #4400

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

Change the command line call for tflint to remove the deprecations eliminated from tflint via [this PR](https://github.com/terraform-linters/tflint/pull/1687).

## Readiness Checklist

### Author/Contributor
- [ x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
