### PR TITLE
Bumps PyYAML to 6.0.1

### DIFF
--- a/dependencies/python/ansible-lint.txt
+++ b/dependencies/python/ansible-lint.txt
@@ -19,7 +19,7 @@ platformdirs==3.5.1
 pycparser==2.21
 Pygments==2.15.1
 pyrsistent==0.19.3
-PyYAML==6.0
+PyYAML==6.0.1
 resolvelib==0.8.1
 rich==13.3.5
 ruamel.yaml==0.17.21

--- a/dependencies/python/cfn-lint.txt
+++ b/dependencies/python/cfn-lint.txt
@@ -16,7 +16,7 @@ pbr==5.11.1
 pydantic==1.10.9
 pyrsistent==0.19.3
 python-dateutil==2.8.2
-PyYAML==6.0
+PyYAML==6.0.1
 regex==2023.6.3
 s3transfer==0.6.0
 sarif-om==1.0.4

--- a/dependencies/python/snakemake.txt
+++ b/dependencies/python/snakemake.txt
@@ -22,7 +22,7 @@ platformdirs==3.5.1
 psutil==5.9.5
 PuLP==2.7.0
 pyrsistent==0.19.3
-PyYAML==6.0
+PyYAML==6.0.1
 requests==2.28.2
 reretry==0.11.8
 smart-open==6.3.0

--- a/dependencies/python/sqlfluff.txt
+++ b/dependencies/python/sqlfluff.txt
@@ -12,7 +12,7 @@ pathspec==0.11.1
 pluggy==1.0.0
 Pygments==2.15.1
 pytest==7.3.1
-PyYAML==6.0
+PyYAML==6.0.1
 regex==2023.6.3
 sqlfluff==2.1.2
 tblib==1.7.0

--- a/dependencies/python/yamllint.txt
+++ b/dependencies/python/yamllint.txt
@@ -1,3 +1,3 @@
 pathspec==0.11.1
-PyYAML==6.0
+PyYAML==6.0.1
 yamllint==1.31.0

--- a/dependencies/python/yq.txt
+++ b/dependencies/python/yq.txt
@@ -1,5 +1,5 @@
 argcomplete==3.0.8
-PyYAML==6.0
+PyYAML==6.0.1
 tomlkit==0.11.8
 xmltodict==0.13.0
 yq==3.2.2


### PR DESCRIPTION
There's some conflict where PyYAML 6.0.0 and Cython 3.0 do not play well together, this version fixes that.

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
