### PR TITLE
Fix typo on .markdown-lint.yml

### DIFF
--- a/TEMPLATES/.markdown-lint.yml
+++ b/TEMPLATES/.markdown-lint.yml
@@ -22,7 +22,7 @@ MD004: false                  # Unordered list style
 MD007:
   indent: 2                   # Unordered list indentation
 MD013:
-  line_length: 400            # Line length 80 is far to short
+  line_length: 400            # Line length 80 is far too short
 MD026:
   punctuation: ".,;:!。，；:"  # List of not allowed
 MD029: false                  # Ordered list item prefix


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Typo: “far to short” ⇒ “far too short”.
2. This change is a trivial comment change.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
