### PR TITLE
Changing DEFAULT_BRANCH in README to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ name: Lint Code Base
 on:
   push:
     branches-ignore: [master, main]
-    # Remove the line above to run when pushing to master
+    # Remove the line above to run when pushing to master or main
   pull_request:
     branches: [master, main]
 
@@ -187,7 +187,7 @@ jobs:
         uses: super-linter/super-linter@v5
         env:
           VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: master
+          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
@@ -232,7 +232,7 @@ Example usage:
   uses: super-linter/super-linter@v5
   env:
     VALIDATE_ALL_CODEBASE: false
-    DEFAULT_BRANCH: master
+    DEFAULT_BRANCH: main
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
@@ -258,7 +258,7 @@ Example usage:
   uses: super-linter/super-linter/slim@v5
   env:
     VALIDATE_ALL_CODEBASE: false
-    DEFAULT_BRANCH: master
+    DEFAULT_BRANCH: main
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
@@ -456,7 +456,7 @@ name: Lint Code Base
 on:
   push:
     branches-ignore: [master, main]
-    # Remove the line above to run when pushing to master
+    # Remove the line above to run when pushing to master or main
   pull_request:
     branches: [master, main]
 
@@ -490,7 +490,7 @@ jobs:
         uses: super-linter/super-linter@v5
         env:
           VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: master
+          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 ```


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Changes `DEFAULT_BRANCH` to `main`. `master` is still the default, however, the README does not align with the referenced `TEMPLATES/linter.yml` which is fixed with this PR.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
