### PR TITLE
Fix docker image name in docs

### DIFF
--- a/docs/run-linter-locally.md
+++ b/docs/run-linter-locally.md
@@ -17,14 +17,14 @@ You can follow the link below on how to install and configure **Docker** on your
 ## Download the latest Super-Linter Docker container
 
 - Pull the latest **Docker** container down from **DockerHub**
-  - `docker pull super-linter/super-linter:latest`
+  - `docker pull ghcr.io/super-linter/super-linter:latest`
     Once the container has been downloaded to your local environment, you can then begin the process, or running the container against your codebase.
 
 ## Run the container Locally
 
 - You can run the container locally with the following **Base** flags to run your code:
   - `docker run -e RUN_LOCAL=true -e USE_FIND_ALGORITHM=true -v /path/to/local/codebase:/tmp/lint super-linter/super-linter`
-    - To run against a single file you can use: `docker run -e RUN_LOCAL=true -e USE_FIND_ALGORITHM=true -v /path/to/local/codebase/file:/tmp/lint/file super-linter/super-linter`
+    - To run against a single file you can use: `docker run -e RUN_LOCAL=true -e USE_FIND_ALGORITHM=true -v /path/to/local/codebase/file:/tmp/lint/file ghcr.io/super-linter/super-linter`
   - **NOTE:** You need to pass the `RUN_LOCAL` flag to bypass some of the GitHub Actions checks, as well as the mapping of your local codebase to `/tmp/lint` so that the linter can pick up the code
   - **NOTE:** If you want to override the `/tmp/lint` folder, you can set the `DEFAULT_WORKSPACE` environment variable to point to the folder you'd prefer to scan.
   - **NOTE:** The flag:`RUN_LOCAL` will set: `VALIDATE_ALL_CODEBASE` to true. This means it will scan **all** the files in the directory you have mapped. If you want to only validate a subset of your codebase, map a folder with only the files you wish to have linted
@@ -57,7 +57,7 @@ This always runs the local docker based linting.
 docker run --rm \
     -e RUN_LOCAL=true \
     --env-file ".github/super-linter.env" \
-    -v "$PWD":/tmp/lint super-linter/super-linter:v5
+    -v "$PWD":/tmp/lint ghcr.io/super-linter/super-linter:v5
 ```
 
 ### scripts/test
@@ -103,7 +103,7 @@ jobs:
 
 If you need to run the container locally and gain access to its command-line, you can run the following command:
 
-- `docker run -it --entrypoint /bin/bash super-linter/super-linter`
+- `docker run -it --entrypoint /bin/bash ghcr.io/super-linter/super-linter`
 - This will drop you in the command-line of the docker container for any testing or troubleshooting that may be needed.
 
 ### Found issues


### PR DESCRIPTION

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

There isn't super-linter account on Docker Hub:
https://hub.docker.com/u/super-linter

I think the image should be coming from `ghcr.io/super-linter/super-linter`

I added missing `ghcr.io/` in docs about running the super-lint locally.

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Image tag from `super-linter/super-linter` to `ghcr.io/super-linter/super-linter`

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
