### PR TITLE
Update chktex docker image

### DIFF
--- a/.automation/test/latex/latex_good_1.tex
+++ b/.automation/test/latex/latex_good_1.tex
@@ -55,7 +55,7 @@ in plain TeX---are the key
 % Using DashExcpt
 The Birch--Swinnerton-Dyer conjecture is correct.
 %The Birch--Swinnerton--Dyer conjecture is not correct.
-The Birch-Swinnerton-Dyer conjecture is not correct (but not caught).
+%The Birch-Swinnerton-Dyer conjecture is not correct (but not caught).
 
 % Warning 9-10
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 #########################################
 FROM tenable/terrascan:1.18.3 as terrascan
 FROM alpine/terragrunt:1.5.5 as terragrunt
-FROM assignuser/chktex-alpine:v0.2.0 as chktex
+FROM ghcr.io/assignuser/chktex-alpine:v0.2.0 as chktex
 FROM dotenvlinter/dotenv-linter:3.3.0 as dotenv-linter
 FROM ghcr.io/awkbar-devops/clang-format:v1.0.2 as clang-format
 FROM ghcr.io/terraform-linters/tflint-bundle:v0.47.0.0 as tflint

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 #########################################
 FROM tenable/terrascan:1.18.3 as terrascan
 FROM alpine/terragrunt:1.5.5 as terragrunt
-FROM assignuser/chktex-alpine:v0.1.1 as chktex
+FROM assignuser/chktex-alpine:v0.2.0 as chktex
 FROM dotenvlinter/dotenv-linter:3.3.0 as dotenv-linter
 FROM ghcr.io/awkbar-devops/clang-format:v1.0.2 as clang-format
 FROM ghcr.io/terraform-linters/tflint-bundle:v0.47.0.0 as tflint


### PR DESCRIPTION
## Proposed Changes

I have updated the [chktex-alpine](https://github.com/assignUser/chktex-alpine/pkgs/container/chktex-alpine/122308127?tag=v0.2.0) package to be multi-arch with linux/arm64. I have stopped updating the package on docker hub and have switched to ghcr.io as well. This also updates chktex to version 1.7.8 from 1.7.6

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
