### PR TITLE
Pass correct yamllint config file to command

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -998,9 +998,9 @@ LINTER_COMMANDS_ARRAY['TYPESCRIPT_STANDARD']="ts-standard --parser @typescript-e
 LINTER_COMMANDS_ARRAY['TYPESCRIPT_PRETTIER']="prettier --check"
 LINTER_COMMANDS_ARRAY['XML']="xmllint"
 if [ "${YAML_ERROR_ON_WARNING}" == 'false' ]; then
-  LINTER_COMMANDS_ARRAY['YAML']="yamllint -c ${YAML_LINTER_RULES} -f parsable"
+  LINTER_COMMANDS_ARRAY['YAML']="yamllint -c ${YAML_FILE_NAME} -f parsable"
 else
-  LINTER_COMMANDS_ARRAY['YAML']="yamllint --strict -c ${YAML_LINTER_RULES} -f parsable"
+  LINTER_COMMANDS_ARRAY['YAML']="yamllint --strict -c ${YAML_FILE_NAME} -f parsable"
 fi
 
 debug "--- Linter commands ---"


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #4377

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

The README documents using `YAML_CONFIG_FILE` to configure `yamllint`, but currently it does not get passed correctly.

Instead, [`YAML_FILE_NAME`](https://github.com/super-linter/super-linter/blob/main/lib/linter.sh#L219) gets set but never referenced

As far as I can tell, `YAML_LINTER_RULES` is used when actually calling `yamllint`, but it never gets set, which seems like where the issue lies and should instead be `YAML_FILE_NAME`.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

N/A I believe, since this is to make the code match the documentation.

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
