### PR TITLE
Only `warn` for failure to install R packages

### DIFF
--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -493,7 +493,7 @@ function RunAdditionalInstalls() {
       ##############################
       debug "INSTALL_CMD:[${INSTALL_CMD}]"
       if [ "${ERROR_CODE}" -ne 0 ]; then
-        fatal "ERROR: Failed to install the build package at:[${BUILD_PKG}]"
+        warn "ERROR: Failed to install the build package at:[${BUILD_PKG}]"
       fi
     fi
   fi


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes the bug introduced in https://github.com/super-linter/super-linter/pull/3501

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

R package installation is _not needed_ for the R linter to work. This is called static code analysis for a reason.

## Proposed Changes

Just yield a warning instead of abruptly failing the workflow if a package cannot be installed. This was the behavior for years before and worked just fine.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
