### PR TITLE
Fix image name in run-linter-locally.md

### DIFF
--- a/docs/run-linter-locally.md
+++ b/docs/run-linter-locally.md
@@ -23,7 +23,7 @@ You can follow the link below on how to install and configure **Docker** on your
 ## Run the container Locally
 
 - You can run the container locally with the following **Base** flags to run your code:
-  - `docker run -e RUN_LOCAL=true -e USE_FIND_ALGORITHM=true -v /path/to/local/codebase:/tmp/lint super-linter/super-linter`
+  - `docker run -e RUN_LOCAL=true -e USE_FIND_ALGORITHM=true -v /path/to/local/codebase:/tmp/lint ghcr.io/super-linter/super-linter`
     - To run against a single file you can use: `docker run -e RUN_LOCAL=true -e USE_FIND_ALGORITHM=true -v /path/to/local/codebase/file:/tmp/lint/file ghcr.io/super-linter/super-linter`
   - **NOTE:** You need to pass the `RUN_LOCAL` flag to bypass some of the GitHub Actions checks, as well as the mapping of your local codebase to `/tmp/lint` so that the linter can pick up the code
   - **NOTE:** If you want to override the `/tmp/lint` folder, you can set the `DEFAULT_WORKSPACE` environment variable to point to the folder you'd prefer to scan.


### PR DESCRIPTION
The image name was missing `ghcr.io`, which caused the command to fail.