### PR TITLE
Revert exact version pinning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,19 +98,6 @@ jobs:
           # Full git history is needed to get a proper list of commits and tags
           fetch-depth: 0
 
-      - name: Update action.yml
-        run: yq '.runs.image = "docker://ghcr.io/super-linter/super-linter:${{ env.RELEASE_VERSION }}"' -i action.yml
-
-      - name: Update slim/action.yml
-        run: yq '.runs.image = "docker://ghcr.io/super-linter/super-linter:slim-${{ env.RELEASE_VERSION }}"' -i slim/action.yml
-
-      - uses: EndBug/add-and-commit@v9 # You can change this to use a specific version.
-        with:
-          add: 'action.yml slim/action.yml'
-          default_author: github_actions
-          message: 'Automated update of action.yml and slim/action.yml version numbers'
-          push: origin main --force
-
       # We use ^{} to recursively deference the tag to get the commit the tag is pointing at.
       # Then, we use that reference to create new tags, so that the new tags point to the commit
       # the original tag was pointing to, and not to the original tag.


### PR DESCRIPTION
Exact version pinning wont be available for super-linter until merge queue and gh cli merges are compatible. See https://github.com/cli/cli/issues/7213

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->



<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Revert release workflow code that attempts to change the version pinned in the action.yml files

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
