### PR TITLE
Fix target key in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,7 +26,7 @@ jobs:
             target: slim
           - environment: Production
             prefix: ""
-            image-id: standard
+            target: standard
     timeout-minutes: 60
     env:
       CONTAINER_IMAGE_ID: "ghcr.io/super-linter/super-linter:${{ matrix.images.prefix }}latest"


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #4771 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

Fix the CD workflow by passing the correct target when building the non-slim image.

Merge this after #4772 and #4778 to check if this fixes things.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
