### PR TITLE
Use the same image tags in CI and CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,6 +28,8 @@ jobs:
             prefix: ""
             image-id: standard
     timeout-minutes: 60
+    env:
+      CONTAINER_IMAGE_TAG: "${{ matrix.images.prefix }}latest"
     steps:
       - name: Free Disk space
         shell: bash
@@ -55,7 +57,7 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            ghcr.io/super-linter/super-linter:${{ matrix.images.prefix }}latest
+            ghcr.io/super-linter/super-linter:${{ env.CONTAINER_IMAGE_TAG }}
           target: "${{ matrix.images.target }}"
 
       - name: Run Test Suite
@@ -71,9 +73,7 @@ jobs:
           -e RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES="default.json,hoge.json" \
           -e ERROR_ON_MISSING_EXEC_BIT=true \
           -v "${GITHUB_WORKSPACE}:/tmp/lint" \
-          "ghcr.io/super-linter/super-linter:${tag}"
-        env:
-          tag: ${{ matrix.images.prefix }}latest
+          "ghcr.io/super-linter/super-linter:${CONTAINER_IMAGE_TAG}"
 
       - name: Lint Entire Codebase
         run: |
@@ -84,9 +84,7 @@ jobs:
           -e RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES="default.json,hoge.json" \
           -e ERROR_ON_MISSING_EXEC_BIT=true \
           -v "${GITHUB_WORKSPACE}:/tmp/lint" \
-          "ghcr.io/super-linter/super-linter:${tag}"
-        env:
-          tag: ${{ matrix.images.prefix }}latest
+          "ghcr.io/super-linter/super-linter:${CONTAINER_IMAGE_TAG}"
 
       - name: Login to GHCR
         uses: docker/login-action@v3.0.0
@@ -117,7 +115,7 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            ghcr.io/super-linter/super-linter:${{ matrix.images.prefix }}latest
+            ghcr.io/super-linter/super-linter:${{ env.CONTAINER_IMAGE_TAG }}
           target: "${{ matrix.images.target }}"
 
       - name: Update ${{ matrix.images.environment }} Deployment

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,6 +30,8 @@ jobs:
     timeout-minutes: 60
     env:
       CONTAINER_IMAGE_TAG: "${{ matrix.images.prefix }}latest"
+      CONTAINER_IMAGE_ID: "ghcr.io/super-linter/super-linter:${{ env.CONTAINER_IMAGE_TAG }}"
+      CONTAINER_IMAGE_TARGET: "${{ matrix.images.target }}"
     steps:
       - name: Free Disk space
         shell: bash
@@ -57,11 +59,11 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            ghcr.io/super-linter/super-linter:${{ env.CONTAINER_IMAGE_TAG }}
+            ${{ env.CONTAINER_IMAGE_ID }}
           target: "${{ matrix.images.target }}"
 
       - name: Run Test Suite
-        run: make IMAGE=${{ matrix.images.target }} test
+        run: make test
 
       - name: Run Super-Linter Tests
         run: |
@@ -73,7 +75,7 @@ jobs:
           -e RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES="default.json,hoge.json" \
           -e ERROR_ON_MISSING_EXEC_BIT=true \
           -v "${GITHUB_WORKSPACE}:/tmp/lint" \
-          "ghcr.io/super-linter/super-linter:${CONTAINER_IMAGE_TAG}"
+          "${CONTAINER_IMAGE_ID}"
 
       - name: Lint Entire Codebase
         run: |
@@ -84,7 +86,7 @@ jobs:
           -e RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES="default.json,hoge.json" \
           -e ERROR_ON_MISSING_EXEC_BIT=true \
           -v "${GITHUB_WORKSPACE}:/tmp/lint" \
-          "ghcr.io/super-linter/super-linter:${CONTAINER_IMAGE_TAG}"
+          "${CONTAINER_IMAGE_ID}"
 
       - name: Login to GHCR
         uses: docker/login-action@v3.0.0
@@ -115,7 +117,7 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            ghcr.io/super-linter/super-linter:${{ env.CONTAINER_IMAGE_TAG }}
+            ${{ env.CONTAINER_IMAGE_ID }}
           target: "${{ matrix.images.target }}"
 
       - name: Update ${{ matrix.images.environment }} Deployment

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,8 +29,7 @@ jobs:
             image-id: standard
     timeout-minutes: 60
     env:
-      CONTAINER_IMAGE_TAG: "${{ matrix.images.prefix }}latest"
-      CONTAINER_IMAGE_ID: "ghcr.io/super-linter/super-linter:${{ env.CONTAINER_IMAGE_TAG }}"
+      CONTAINER_IMAGE_ID: "ghcr.io/super-linter/super-linter:${{ matrix.images.prefix }}latest"
       CONTAINER_IMAGE_TARGET: "${{ matrix.images.target }}"
     steps:
       - name: Free Disk space

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,7 +73,7 @@ jobs:
           -v "${GITHUB_WORKSPACE}:/tmp/lint" \
           "ghcr.io/super-linter/super-linter:${tag}"
         env:
-          tag: ${{ matrix.images.target }}
+          tag: ${{ matrix.images.prefix }}latest
 
       - name: Lint Entire Codebase
         run: |
@@ -86,7 +86,7 @@ jobs:
           -v "${GITHUB_WORKSPACE}:/tmp/lint" \
           "ghcr.io/super-linter/super-linter:${tag}"
         env:
-          tag: ${{ matrix.images.target }}
+          tag: ${{ matrix.images.prefix }}latest
 
       - name: Login to GHCR
         uses: docker/login-action@v3.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,10 @@ jobs:
       fail-fast: false
       matrix:
         images:
-          - target: slim
-          - target: standard
+          - prefix: slim-
+            target: slim
+          - prefix: ""
+            target: standard
     timeout-minutes: 60
     steps:
       - name: Free Disk space
@@ -52,7 +54,7 @@ jobs:
           push: false
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          tags: ghcr.io/super-linter/super-linter:${{ matrix.images.target }}
+          tags: ghcr.io/super-linter/super-linter:${{ matrix.images.prefix }}latest
           target: "${{ matrix.images.target }}"
 
       - name: Test Local Action
@@ -81,7 +83,7 @@ jobs:
           -v "${GITHUB_WORKSPACE}:/tmp/lint" \
           "ghcr.io/super-linter/super-linter:${tag}"
         env:
-          tag: ${{ matrix.images.target }}
+          tag: ${{ matrix.images.prefix }}latest
 
       - name: Lint Entire Codebase
         run: |
@@ -94,4 +96,4 @@ jobs:
           -v "${GITHUB_WORKSPACE}:/tmp/lint" \
           "ghcr.io/super-linter/super-linter:${tag}"
         env:
-          tag: ${{ matrix.images.target }}
+          tag: ${{ matrix.images.prefix }}latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Update action.yml
         run: |
-          yq '.runs.image = "docker://ghcr.io/super-linter/super-linter:env(CONTAINER_IMAGE_TAG)"' -i action.yml
+          yq '.runs.image = docker://ghcr.io/super-linter/super-linter:env(CONTAINER_IMAGE_TAG)' -i action.yml
           echo "Action file contents:"
           cat action.yml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,10 @@ jobs:
           fetch-depth: 0
 
       - name: Update action.yml
-        run: yq '.runs.image = "docker://ghcr.io/super-linter/super-linter:${CONTAINER_IMAGE_TAG}"' -i action.yml
+        run: |
+          yq '.runs.image = "docker://ghcr.io/super-linter/super-linter:env(CONTAINER_IMAGE_TAG)"' -i action.yml
+          echo "Action file contents:"
+          cat action.yml
 
       - name: Retrieve Datetime
         run: echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "${GITHUB_ENV}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Update action.yml
         run: |
+          echo "yq version: $(yq --version)"
           yq '.runs.image = docker://ghcr.io/super-linter/super-linter:env(CONTAINER_IMAGE_TAG)' -i action.yml
           echo "Action file contents:"
           cat action.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
           - prefix: ""
             target: standard
     timeout-minutes: 60
+    env:
+      CONTAINER_IMAGE_TAG: "${{ matrix.images.prefix }}latest"
     steps:
       - name: Free Disk space
         shell: bash
@@ -36,7 +38,7 @@ jobs:
           fetch-depth: 0
 
       - name: Update action.yml
-        run: yq '.runs.image = "docker://ghcr.io/super-linter/super-linter:${{ matrix.images.target }}"' -i action.yml
+        run: yq '.runs.image = "docker://ghcr.io/super-linter/super-linter:${CONTAINER_IMAGE_TAG}"' -i action.yml
 
       - name: Retrieve Datetime
         run: echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "${GITHUB_ENV}"
@@ -54,7 +56,7 @@ jobs:
           push: false
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          tags: ghcr.io/super-linter/super-linter:${{ matrix.images.prefix }}latest
+          tags: ghcr.io/super-linter/super-linter:${{ env.CONTAINER_IMAGE_TAG }}
           target: "${{ matrix.images.target }}"
 
       - name: Test Local Action
@@ -81,9 +83,7 @@ jobs:
           -e RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES="default.json,hoge.json" \
           -e ERROR_ON_MISSING_EXEC_BIT=true \
           -v "${GITHUB_WORKSPACE}:/tmp/lint" \
-          "ghcr.io/super-linter/super-linter:${tag}"
-        env:
-          tag: ${{ matrix.images.prefix }}latest
+          "ghcr.io/super-linter/super-linter:${CONTAINER_IMAGE_TAG}"
 
       - name: Lint Entire Codebase
         run: |
@@ -94,6 +94,4 @@ jobs:
           -e RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES="default.json,hoge.json" \
           -e ERROR_ON_MISSING_EXEC_BIT=true \
           -v "${GITHUB_WORKSPACE}:/tmp/lint" \
-          "ghcr.io/super-linter/super-linter:${tag}"
-        env:
-          tag: ${{ matrix.images.prefix }}latest
+          "ghcr.io/super-linter/super-linter:${CONTAINER_IMAGE_TAG}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
     timeout-minutes: 60
     env:
       CONTAINER_IMAGE_TAG: "${{ matrix.images.prefix }}latest"
+      CONTAINER_IMAGE_ID: "ghcr.io/super-linter/super-linter:${{ env.CONTAINER_IMAGE_TAG }}"
+      CONTAINER_IMAGE_TARGET: "${{ matrix.images.target }}"
     steps:
       - name: Free Disk space
         shell: bash
@@ -40,7 +42,7 @@ jobs:
       - name: Update action.yml
         run: |
           echo "yq version: $(yq --version)"
-          yq '.runs.image = "docker://ghcr.io/super-linter/super-linter:" + env(CONTAINER_IMAGE_TAG)' -i action.yml
+          yq '.runs.image = env(CONTAINER_IMAGE_ID)' -i action.yml
           echo "Action file contents:"
           cat action.yml
 
@@ -60,7 +62,8 @@ jobs:
           push: false
           secrets: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          tags: ghcr.io/super-linter/super-linter:${{ env.CONTAINER_IMAGE_TAG }}
+          tags: |
+            ${{ env.CONTAINER_IMAGE_ID }}
           target: "${{ matrix.images.target }}"
 
       - name: Test Local Action
@@ -75,7 +78,7 @@ jobs:
           RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES: "default.json,hoge.json"
 
       - name: Run Test Suite
-        run: make IMAGE=${{ matrix.images.target }} test
+        run: make test
 
       - name: Run Super-Linter Tests
         run: |
@@ -87,7 +90,7 @@ jobs:
           -e RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES="default.json,hoge.json" \
           -e ERROR_ON_MISSING_EXEC_BIT=true \
           -v "${GITHUB_WORKSPACE}:/tmp/lint" \
-          "ghcr.io/super-linter/super-linter:${CONTAINER_IMAGE_TAG}"
+          "${CONTAINER_IMAGE_ID}"
 
       - name: Lint Entire Codebase
         run: |
@@ -98,4 +101,4 @@ jobs:
           -e RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES="default.json,hoge.json" \
           -e ERROR_ON_MISSING_EXEC_BIT=true \
           -v "${GITHUB_WORKSPACE}:/tmp/lint" \
-          "ghcr.io/super-linter/super-linter:${CONTAINER_IMAGE_TAG}"
+          "${CONTAINER_IMAGE_ID}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,7 @@ jobs:
             target: standard
     timeout-minutes: 60
     env:
-      CONTAINER_IMAGE_TAG: "${{ matrix.images.prefix }}latest"
-      CONTAINER_IMAGE_ID: "ghcr.io/super-linter/super-linter:${{ env.CONTAINER_IMAGE_TAG }}"
+      CONTAINER_IMAGE_ID: "ghcr.io/super-linter/super-linter:${{ matrix.images.prefix }}latest"
       CONTAINER_IMAGE_TARGET: "${{ matrix.images.target }}"
     steps:
       - name: Free Disk space

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Update action.yml
         run: |
           echo "yq version: $(yq --version)"
-          yq '.runs.image = docker://ghcr.io/super-linter/super-linter:env(CONTAINER_IMAGE_TAG)' -i action.yml
+          yq '.runs.image = "docker://ghcr.io/super-linter/super-linter:" + env(CONTAINER_IMAGE_TAG)' -i action.yml
           echo "Action file contents:"
           cat action.yml
 

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,10 @@ inspec: inspec-check ## Run InSpec tests
 		--log-level=debug \
 		-t "docker://$${SUPER_LINTER_TEST_CONTAINER_ID}" \
 	&& docker ps \
-	&& docker kill $(SUPER_LINTER_TEST_CONTAINER_NAME) \
-	&& docker rm $(SUPER_LINTER_TEST_CONTAINER_NAME)
+	&& docker kill $(SUPER_LINTER_TEST_CONTAINER_NAME)
 
 .phony: docker
-docker:
+docker: ## Build the container image
 	@if [ -z "${GITHUB_TOKEN}" ]; then echo "GITHUB_TOKEN environment variable not set. Please set your GitHub Personal Access Token."; exit 1; fi
 	DOCKER_BUILDKIT=1 docker buildx build --load \
 		--build-arg BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
@@ -81,3 +80,7 @@ docker:
 		--build-arg BUILD_VERSION=$(shell git rev-parse --short HEAD) \
 		--secret id=GITHUB_TOKEN,env=GITHUB_TOKEN \
 		-t $(SUPER_LINTER_TEST_CONTAINER_URL) .
+
+.phony: docker-pull
+docker-pull: ## Pull the container image from registry
+	docker pull $(SUPER_LINTER_TEST_CONTAINER_URL)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 all: info test ## Run all targets.
 
 .PHONY: test
-test: info clean inspec kcov prepare-test-reports ## Run tests
+test: info clean inspec ## Run tests
 
 # if this session isn't interactive, then we don't want to allocate a
 # TTY, which would fail, but if it is interactive, we do want to attach
@@ -21,35 +21,6 @@ info: ## Gather information about the runtime environment
 	echo "ls -ahl: $$(ls -ahl)"; \
 	docker images; \
 	docker ps
-
-.PHONY: kcov
-kcov: ## Run kcov
-	docker run --rm $(DOCKER_FLAGS) \
-		--user "$$(id -u)":"$$(id -g)" \
-		-v "$(CURDIR)":/workspace \
-		-w="/workspace" \
-		kcov/kcov \
-		kcov \
-		--bash-parse-files-in-dir=/workspace \
-		--clean \
-		--exclude-pattern=.coverage,.git \
-		--include-pattern=.sh \
-		/workspace/test/.coverage \
-		/workspace/test/runTests.sh
-
-COBERTURA_REPORTS_DESTINATION_DIRECTORY := "$(CURDIR)/test/reports/cobertura"
-
-.PHONY: prepare-test-reports
-prepare-test-reports: ## Prepare the test reports for consumption
-	mkdir -p $(COBERTURA_REPORTS_DESTINATION_DIRECTORY); \
-	COBERTURA_REPORTS="$$(find "$$(pwd)" -name 'cobertura.xml')"; \
-	for COBERTURA_REPORT_FILE_PATH in $$COBERTURA_REPORTS ; do \
-		COBERTURA_REPORT_DIRECTORY_PATH="$$(dirname "$$COBERTURA_REPORT_FILE_PATH")"; \
-		COBERTURA_REPORT_DIRECTORY_NAME="$$(basename "$$COBERTURA_REPORT_DIRECTORY_PATH")"; \
-		COBERTURA_REPORT_DIRECTORY_NAME_NO_SUFFIX="$${COBERTURA_REPORT_DIRECTORY_NAME%.*}"; \
-		mkdir -p "$(COBERTURA_REPORTS_DESTINATION_DIRECTORY)"/"$$COBERTURA_REPORT_DIRECTORY_NAME_NO_SUFFIX"; \
-		cp "$$COBERTURA_REPORT_FILE_PATH" "$(COBERTURA_REPORTS_DESTINATION_DIRECTORY)"/"$$COBERTURA_REPORT_DIRECTORY_NAME_NO_SUFFIX"/cobertura.xml; \
-	done
 
 .PHONY: clean
 clean: ## Clean the workspace
@@ -75,10 +46,10 @@ SUPER_LINTER_TEST_CONTINER_URL := ''
 DOCKERFILE := ''
 IMAGE := ''
 ifeq ($(IMAGE),slim)
-	SUPER_LINTER_TEST_CONTINER_URL := "ghcr.io/super-linter/super-linter:slim"
+	SUPER_LINTER_TEST_CONTINER_URL := "ghcr.io/super-linter/super-linter:slim-latest"
 	IMAGE := "slim"
 else
-	SUPER_LINTER_TEST_CONTINER_URL := "ghcr.io/super-linter/super-linter:standard"
+	SUPER_LINTER_TEST_CONTINER_URL := "ghcr.io/super-linter/super-linter:latest"
 	IMAGE := "standard"
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # Inspired by https://github.com/jessfraz/dotfiles
 
 .PHONY: all
-all: info test ## Run all targets.
+all: info docker test ## Run all targets.
 
 .PHONY: test
-test: info clean inspec ## Run tests
+test: inspec ## Run tests
 
 # if this session isn't interactive, then we don't want to allocate a
 # TTY, which would fail, but if it is interactive, we do want to attach
@@ -22,11 +22,6 @@ info: ## Gather information about the runtime environment
 	docker images; \
 	docker ps
 
-.PHONY: clean
-clean: ## Clean the workspace
-	rm -rf $(CURDIR)/test/.coverage; \
-	rm -rf $(CURDIR)/test/reports
-
 .PHONY: help
 help: ## Show help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -42,25 +37,26 @@ inspec-check: ## Validate inspec profiles
 		test/inspec/super-linter
 
 SUPER_LINTER_TEST_CONTAINER_NAME := "super-linter-test"
-SUPER_LINTER_TEST_CONTINER_URL := ''
+SUPER_LINTER_TEST_CONTAINER_URL := $(CONTAINER_IMAGE_ID)
 DOCKERFILE := ''
-IMAGE := ''
-ifeq ($(IMAGE),slim)
-	SUPER_LINTER_TEST_CONTINER_URL := "ghcr.io/super-linter/super-linter:slim-latest"
-	IMAGE := "slim"
-else
-	SUPER_LINTER_TEST_CONTINER_URL := "ghcr.io/super-linter/super-linter:latest"
-	IMAGE := "standard"
+IMAGE := $(CONTAINER_IMAGE_TARGET)
+
+# Default to stadard
+ifeq ($(IMAGE),)
+IMAGE := "standard"
+endif
+
+# Default to latest
+ifeq ($(SUPER_LINTER_TEST_CONTAINER_URL),)
+SUPER_LINTER_TEST_CONTAINER_URL := "ghcr.io/super-linter/super-linter:latest"
 endif
 
 .PHONY: inspec
 inspec: inspec-check ## Run InSpec tests
-	LOCAL_IMAGE="$$(docker images $(SUPER_LINTER_TEST_CONTINER_URL) |grep 'ghcr.io/super-linter/super-linter')"; \
-	if [ "$$?" -ne 0 ]; then docker build -t $(SUPER_LINTER_TEST_CONTINER_URL) -f Dockerfile .; fi && \
-	DOCKER_CONTAINER_STATE="$$(docker inspect --format "{{.State.Running}}" "$(SUPER_LINTER_TEST_CONTAINER_NAME)" 2>/dev/null || echo "")"; \
-	if [ "$$DOCKER_CONTAINER_STATE" = "true" ]; then docker kill "$(SUPER_LINTER_TEST_CONTAINER_NAME)"; fi && \
-	docker tag $(SUPER_LINTER_TEST_CONTINER_URL) $(SUPER_LINTER_TEST_CONTAINER_NAME) && \
-	SUPER_LINTER_TEST_CONTAINER_ID="$$(docker run -d --name "$(SUPER_LINTER_TEST_CONTAINER_NAME)" --rm -it --entrypoint /bin/ash "$(SUPER_LINTER_TEST_CONTAINER_NAME)" -c "while true; do sleep 1; done")" \
+	DOCKER_CONTAINER_STATE="$$(docker inspect --format "{{.State.Running}}" $(SUPER_LINTER_TEST_CONTAINER_NAME) 2>/dev/null || echo "")"; \
+	if [ "$$DOCKER_CONTAINER_STATE" = "true" ]; then docker kill $(SUPER_LINTER_TEST_CONTAINER_NAME); fi && \
+	docker tag $(SUPER_LINTER_TEST_CONTAINER_URL) $(SUPER_LINTER_TEST_CONTAINER_NAME) && \
+	SUPER_LINTER_TEST_CONTAINER_ID="$$(docker run -d --name $(SUPER_LINTER_TEST_CONTAINER_NAME) --rm -it --entrypoint /bin/ash $(SUPER_LINTER_TEST_CONTAINER_NAME) -c "while true; do sleep 1; done")" \
 	&& docker run $(DOCKER_FLAGS) \
 		--rm \
 		-v "$(CURDIR)":/workspace \
@@ -73,7 +69,8 @@ inspec: inspec-check ## Run InSpec tests
 		--log-level=debug \
 		-t "docker://$${SUPER_LINTER_TEST_CONTAINER_ID}" \
 	&& docker ps \
-	&& docker kill "$(SUPER_LINTER_TEST_CONTAINER_NAME)"
+	&& docker kill $(SUPER_LINTER_TEST_CONTAINER_NAME) \
+	&& docker rm $(SUPER_LINTER_TEST_CONTAINER_NAME)
 
 .phony: docker
 docker:
@@ -83,4 +80,4 @@ docker:
 		--build-arg BUILD_REVISION=$(shell git rev-parse --short HEAD) \
 		--build-arg BUILD_VERSION=$(shell git rev-parse --short HEAD) \
 		--secret id=GITHUB_TOKEN,env=GITHUB_TOKEN \
-		-t ghcr.io/super-linter/super-linter .
+		-t $(SUPER_LINTER_TEST_CONTAINER_URL) .

--- a/docs/run-linter-locally.md
+++ b/docs/run-linter-locally.md
@@ -5,8 +5,9 @@ If you want to test locally against the **Super-Linter** to test your branch of 
 - Clone your testing source code to your local environment
 - Install Docker to your local environment
 - Pull the container down
-- Run the container
-- Debug/Troubleshoot
+- Run the container locally
+- Run the test suite locally
+- Troubleshoot
 
 ## Install Docker to your local machine
 
@@ -95,6 +96,30 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: develop
+```
+
+## Build the container image and run the test suite locally
+
+You can run the test suite locally with the following command:
+
+```shell
+make
+```
+
+The test suite will build the container image and run the test suite against a
+a container that is an instance of that container image.
+
+### Run the test suite against an arbitrary super-linter container image
+
+You can run the test suite against an arbitrary super-linter container image.
+
+Here is an example that runs the test suite against the `standard` flavor of the
+`v5.4.3` image.
+
+```shell
+CONTAINER_IMAGE_ID="ghcr.io/super-linter/super-linter:v5.4.3" \
+CONTAINER_IMAGE_TARGET="standard" \
+make docker-pull test
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #4777
Fixes #4776

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Use the same image tags for both CI and CD workflows.
2. Dynamically set the image ID in Makefile.
3. Remove unneeded coverage report commands from Makefile.
4. Document how to run the test suite against arbitrary super-linter images.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
