### PR TITLE
Change WORKDIR in script, not relying on docker run -w by user

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -502,7 +502,7 @@ GetGitHubVars() {
 
     info "Linting all files in mapped directory:[${GITHUB_WORKSPACE}]"
 
-    pushd "$GITHUB_WORKSPACE" >/dev/null || exit 1
+    pushd "${GITHUB_WORKSPACE}" >/dev/null || exit 1
 
     # No need to touch or set the GITHUB_SHA
     # No need to touch or set the GITHUB_EVENT_PATH

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -502,7 +502,7 @@ GetGitHubVars() {
 
     info "Linting all files in mapped directory:[${GITHUB_WORKSPACE}]"
 
-    pushd "$GITHUB_WORKSPACE" >/dev/null || exit
+    pushd "$GITHUB_WORKSPACE" >/dev/null || exit 1
 
     # No need to touch or set the GITHUB_SHA
     # No need to touch or set the GITHUB_EVENT_PATH

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -500,7 +500,9 @@ GetGitHubVars() {
       fatal "Provided volume is not a directory!"
     fi
 
-    info "Linting all files in mapped directory:[${DEFAULT_WORKSPACE}]"
+    info "Linting all files in mapped directory:[${GITHUB_WORKSPACE}]"
+
+    pushd "$GITHUB_WORKSPACE" >/dev/null || exit
 
     # No need to touch or set the GITHUB_SHA
     # No need to touch or set the GITHUB_EVENT_PATH


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #4495

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

pushd to `$DEFAULT_WORKSPACE` before resolving files

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
