### PR TITLE
Fixes Regex to match only container files more strictly

### DIFF
--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -430,7 +430,7 @@ function BuildFileList() {
     elif [[ "${FILE_TYPE}" != "tap" ]] && [[ "${FILE_TYPE}" != "yml" ]] &&
       [[ "${FILE_TYPE}" != "yaml" ]] && [[ "${FILE_TYPE}" != "json" ]] &&
       [[ "${FILE_TYPE}" != "xml" ]] &&
-      [[ "${BASE_FILE}" =~ "^(.+\.)?(contain|dock)erfile$" ]]; then
+      [[ "${BASE_FILE}" =~ ^(.+\.)?(contain|dock)erfile$ ]]; then
 
       ################################
       # Append the file to the array #

--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -430,7 +430,7 @@ function BuildFileList() {
     elif [[ "${FILE_TYPE}" != "tap" ]] && [[ "${FILE_TYPE}" != "yml" ]] &&
       [[ "${FILE_TYPE}" != "yaml" ]] && [[ "${FILE_TYPE}" != "json" ]] &&
       [[ "${FILE_TYPE}" != "xml" ]] &&
-      [[ echo "${BASE_FILE}" | grep -qiE "^(.+\.)?(Docker|Container)file$" ]]; then
+      [[ echo "${BASE_FILE}" =~  ".*(contain|dock)erfile$" ]]; then
 
       ################################
       # Append the file to the array #
@@ -870,10 +870,6 @@ function BuildFileList() {
     debug "Adding the root of the workspaces to the list of files and directories to lint with JSCPD..."
     FILE_ARRAY_JSCPD+=("${GITHUB_WORKSPACE}")
   fi
-
-  # Debug print of the ansible directory
-  echo "Print the ANSIBLE_DIRECTORY contents to see if tests exist"
-  ls $ANSIBLE_DIRECTORY
 
   ################
   # Footer print #

--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -428,7 +428,10 @@ function BuildFileList() {
     ########################
     # Use BASE_FILE here because FILE_TYPE is not reliable when there is no file extension
     elif [[ "${FILE_TYPE}" != "tap" ]] && [[ "${FILE_TYPE}" != "yml" ]] &&
-      [[ "${FILE_TYPE}" != "yaml" ]] && [[ "${FILE_TYPE}" != "json" ]] && [[ "${FILE_TYPE}" != "xml" ]] && [[ "${BASE_FILE}" =~ .*(contain|dock)erfile.* ]]; then
+      [[ "${FILE_TYPE}" != "yaml" ]] && [[ "${FILE_TYPE}" != "json" ]] &&
+      [[ "${FILE_TYPE}" != "xml" ]] &&
+      [[ echo "${BASE_FILE}" | grep -qiE "^(.+\.)?(Docker|Container)file$" ]]; then
+
       ################################
       # Append the file to the array #
       ################################

--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -871,6 +871,10 @@ function BuildFileList() {
     FILE_ARRAY_JSCPD+=("${GITHUB_WORKSPACE}")
   fi
 
+  # Debug print of the ansible directory
+  echo "Print the ANSIBLE_DIRECTORY contents to see if tests exist"
+  ls $ANSIBLE_DIRECTORY
+
   ################
   # Footer print #
   ################

--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -430,7 +430,7 @@ function BuildFileList() {
     elif [[ "${FILE_TYPE}" != "tap" ]] && [[ "${FILE_TYPE}" != "yml" ]] &&
       [[ "${FILE_TYPE}" != "yaml" ]] && [[ "${FILE_TYPE}" != "json" ]] &&
       [[ "${FILE_TYPE}" != "xml" ]] &&
-      [[ "${BASE_FILE}" =~  ".*(contain|dock)erfile$" ]]; then
+      [[ "${BASE_FILE}" =~  "^(.+\.)?(contain|dock)erfile$" ]]; then
 
       ################################
       # Append the file to the array #

--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -430,7 +430,7 @@ function BuildFileList() {
     elif [[ "${FILE_TYPE}" != "tap" ]] && [[ "${FILE_TYPE}" != "yml" ]] &&
       [[ "${FILE_TYPE}" != "yaml" ]] && [[ "${FILE_TYPE}" != "json" ]] &&
       [[ "${FILE_TYPE}" != "xml" ]] &&
-      [[ "${BASE_FILE}" =~  "^(.+\.)?(contain|dock)erfile$" ]]; then
+      [[ "${BASE_FILE}" =~ "^(.+\.)?(contain|dock)erfile$" ]]; then
 
       ################################
       # Append the file to the array #

--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -430,7 +430,7 @@ function BuildFileList() {
     elif [[ "${FILE_TYPE}" != "tap" ]] && [[ "${FILE_TYPE}" != "yml" ]] &&
       [[ "${FILE_TYPE}" != "yaml" ]] && [[ "${FILE_TYPE}" != "json" ]] &&
       [[ "${FILE_TYPE}" != "xml" ]] &&
-      [[ echo "${BASE_FILE}" =~  ".*(contain|dock)erfile$" ]]; then
+      [[ "${BASE_FILE}" =~  ".*(contain|dock)erfile$" ]]; then
 
       ################################
       # Append the file to the array #


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #4846 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

We check for files with the name (case insensitive):
- Dockerfile
- Containerfile
- <anything>.Dockerfile
- <anything>.Containerfile

This appears to protect us against catching files with a name like `Dockerfile.md`

I tested the regex like so:

![Screenshot from 2023-11-13 16-07-07](https://github.com/super-linter/super-linter/assets/1758164/75836dd4-990a-4ec7-b6b1-a907449c8a31)


## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
