### PR TITLE
Automatically handle Java dependencies updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,15 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+
+  # Maintain dependencies for Java
+  - package-ecosystem: "gradle"
+    directory: "/dependencies/checkstyle"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "gradle"
+    directory: "/dependencies/google-java-format"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,12 +34,10 @@ FROM python:3.11.5-alpine3.17 as base_image
 ################################
 # Set ARG values used in Build #
 ################################
-ARG CHECKSTYLE_VERSION='10.3.4'
 ARG CLJ_KONDO_VERSION='2023.05.18'
 # Dart Linter
 ## stable dart sdk: https://dart.dev/get-dart#release-channels
 ARG DART_VERSION='2.8.4'
-ARG GOOGLE_JAVA_FORMAT_VERSION='1.18.1'
 ## install alpine-pkg-glibc (glibc compatibility layer package for Alpine Linux)
 ARG GLIBC_VERSION='2.34-r0'
 ARG KTLINT_VERSION='0.47.1'

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ RUN apk add --no-cache \
 ########################################
 # Copy dependencies files to container #
 ########################################
-COPY dependencies/* /
+COPY dependencies/ /
 
 ###################################################################
 # Install Dependencies                                            #

--- a/dependencies/checkstyle/build.gradle
+++ b/dependencies/checkstyle/build.gradle
@@ -1,0 +1,12 @@
+repositories {
+  mavenLocal()
+  mavenCentral()
+}
+
+// Hold this dependency here so we can get automated updates using DependaBot
+dependencies {
+  implementation 'com.puppycrawl.tools:checkstyle:10.3.4'
+}
+
+group 'com.github.super-linter'
+version '1.0.0-SNAPSHOT'

--- a/dependencies/google-java-format/build.gradle
+++ b/dependencies/google-java-format/build.gradle
@@ -1,0 +1,12 @@
+repositories {
+  mavenLocal()
+  mavenCentral()
+}
+
+// Hold this dependency here so we can get automated updates using DependaBot
+dependencies {
+  implementation 'com.google.googlejavaformat:google-java-format:1.18.1'
+}
+
+group 'com.github.super-linter'
+version '1.0.0-SNAPSHOT'

--- a/scripts/install-checkstyle.sh
+++ b/scripts/install-checkstyle.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+CHECKSTYLE_VERSION="$(grep <"/dependencies/checkstyle/build.gradle" "checkstyle" | awk -F ':' '{print $2}')"
+echo "Installing Checkstyle: ${CHECKSTYLE_VERSION}"
+
 url=$(curl -s \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \

--- a/scripts/install-checkstyle.sh
+++ b/scripts/install-checkstyle.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-CHECKSTYLE_VERSION="$(grep <"/dependencies/checkstyle/build.gradle" "checkstyle" | awk -F ':' '{print $2}')"
+CHECKSTYLE_VERSION="$(grep <"dependencies/checkstyle/build.gradle" "checkstyle" | awk -F ':' '{print $3}' | tr -d "'")"
 echo "Installing Checkstyle: ${CHECKSTYLE_VERSION}"
 
 url=$(curl -s \

--- a/scripts/install-checkstyle.sh
+++ b/scripts/install-checkstyle.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-CHECKSTYLE_VERSION="$(grep <"dependencies/checkstyle/build.gradle" "checkstyle" | awk -F ':' '{print $3}' | tr -d "'")"
+CHECKSTYLE_VERSION="$(grep <"checkstyle/build.gradle" "checkstyle" | awk -F ':' '{print $3}' | tr -d "'")"
 echo "Installing Checkstyle: ${CHECKSTYLE_VERSION}"
 
 url=$(curl -s \

--- a/scripts/install-google-java-format.sh
+++ b/scripts/install-google-java-format.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-GOOGLE_JAVA_FORMAT_VERSION="$(grep <"dependencies/google-java-format/build.gradle" "google-java-format" | awk -F ':' '{print $2}')"
+GOOGLE_JAVA_FORMAT_VERSION="$(grep <"dependencies/google-java-format/build.gradle" "google-java-format" | awk -F ':' '{print $3}' | tr -d "'")"
 echo "Installing Google Java Format: ${GOOGLE_JAVA_FORMAT_VERSION}"
 
 url=$(curl -s \

--- a/scripts/install-google-java-format.sh
+++ b/scripts/install-google-java-format.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-GOOGLE_JAVA_FORMAT_VERSION="$(grep <"dependencies/google-java-format/build.gradle" "google-java-format" | awk -F ':' '{print $3}' | tr -d "'")"
+GOOGLE_JAVA_FORMAT_VERSION="$(grep <"google-java-format/build.gradle" "google-java-format" | awk -F ':' '{print $3}' | tr -d "'")"
 echo "Installing Google Java Format: ${GOOGLE_JAVA_FORMAT_VERSION}"
 
 url=$(curl -s \

--- a/scripts/install-google-java-format.sh
+++ b/scripts/install-google-java-format.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-GOOGLE_JAVA_FORMAT_VERSION="$(grep <"/dependencies/checkstyle/build.gradle" "checkstyle" | awk -F ':' '{print $2}')"
+GOOGLE_JAVA_FORMAT_VERSION="$(grep <"dependencies/google-java-format/build.gradle" "google-java-format" | awk -F ':' '{print $2}')"
 echo "Installing Google Java Format: ${GOOGLE_JAVA_FORMAT_VERSION}"
 
 url=$(curl -s \

--- a/scripts/install-google-java-format.sh
+++ b/scripts/install-google-java-format.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+GOOGLE_JAVA_FORMAT_VERSION="$(grep <"/dependencies/checkstyle/build.gradle" "checkstyle" | awk -F ':' '{print $2}')"
+echo "Installing Google Java Format: ${GOOGLE_JAVA_FORMAT_VERSION}"
+
 url=$(curl -s \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \


### PR DESCRIPTION
Fixes #4893

## Proposed Changes

1. Move dependency definitions for `google-java-format` and `checkstyle` to Gradle files.
2. Watch these Gradle files for updates with DependaBot
3. Dynamically fetch dependency versions from these Gradle files.

I didn't update the versions of these dependencies so that we can see if DependaBot is going to propose PRs once this is merged.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
