### PR TITLE
Move dependency updates to a dedicated section

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -22,9 +22,10 @@ categories:
       - 'infrastructure'
       - 'automation'
       - 'documentation'
+      - 'performance'
+  - title: 'Dependency updates'
+    labels:
       - 'dependencies'
-  - title: '🏎 Performance'
-    label: 'performance'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 version-resolver:
   major:


### PR DESCRIPTION
## Proposed Changes

1. Move dependency updates to a dedicated section in release notes so other updates are not buried in that section.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
