### PR TITLE
Don't forcefully validate Git repos if not needed

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -100,6 +100,7 @@ jobs:
           -e TEST_CASE_RUN=true \
           -e ANSIBLE_DIRECTORY=.automation/test/ansible \
           -e ACTIONS_RUNNER_DEBUG=true \
+          -e DEFAULT_BRANCH=main \
           -e RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES="default.json,hoge.json" \
           -e ERROR_ON_MISSING_EXEC_BIT=true \
           -e TYPESCRIPT_STANDARD_TSCONFIG_FILE=".github/linters/tsconfig.json" \
@@ -112,6 +113,7 @@ jobs:
           -e RUN_LOCAL=true \
           -e OUTPUT_DETAILS=detailed \
           -e ACTIONS_RUNNER_DEBUG=true \
+          -e DEFAULT_BRANCH=main \
           -e RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES="default.json,hoge.json" \
           -e ERROR_ON_MISSING_EXEC_BIT=true \
           -v "${GITHUB_WORKSPACE}:/tmp/lint" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,6 @@ jobs:
         run: make test
 
       - name: Test super-linter on a subdirectory using find
-        uses: ./
         run: |
           docker run \
           -e RUN_LOCAL=true \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
           -e TEST_CASE_RUN=true \
           -e ANSIBLE_DIRECTORY=.automation/test/ansible \
           -e ACTIONS_RUNNER_DEBUG=true \
+          -e DEFAULT_BRANCH=main \
           -e RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES="default.json,hoge.json" \
           -e ERROR_ON_MISSING_EXEC_BIT=true \
           -e TYPESCRIPT_STANDARD_TSCONFIG_FILE=".github/linters/tsconfig.json" \
@@ -132,6 +133,7 @@ jobs:
           docker run \
           -e RUN_LOCAL=true \
           -e ACTIONS_RUNNER_DEBUG=true \
+          -e DEFAULT_BRANCH=main \
           -e RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES="default.json,hoge.json" \
           -e ERROR_ON_MISSING_EXEC_BIT=true \
           -v "${GITHUB_WORKSPACE}:/tmp/lint" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,16 +114,6 @@ jobs:
       - name: Run Test Suite
         run: make test
 
-      - name: Test super-linter on a subdirectory using find
-        run: |
-          docker run \
-          -e RUN_LOCAL=true \
-          -e ACTIONS_RUNNER_DEBUG=true \
-          -e ERROR_ON_MISSING_EXEC_BIT=true \
-          -e USE_FIND_ALGORITHM=true \
-          -v "${GITHUB_WORKSPACE}/.github:/tmp/lint" \
-          "${CONTAINER_IMAGE_ID}"
-
       - name: Run Super-Linter Tests
         run: |
           docker run \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,17 @@ jobs:
       - name: Run Test Suite
         run: make test
 
+      - name: Test super-linter on a subdirectory using find
+        uses: ./
+        run: |
+          docker run \
+          -e RUN_LOCAL=true \
+          -e ACTIONS_RUNNER_DEBUG=true \
+          -e ERROR_ON_MISSING_EXEC_BIT=true \
+          -e USE_FIND_ALGORITHM=true \
+          -v "${GITHUB_WORKSPACE}/.github:/tmp/lint" \
+          "${CONTAINER_IMAGE_ID}"
+
       - name: Run Super-Linter Tests
         run: |
           docker run \

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ test-find: ## Run super-linter on a subdirectory with USE_FIND_ALGORITHM=true
 		-e RUN_LOCAL=true \
 		-e ACTIONS_RUNNER_DEBUG=true \
 		-e ERROR_ON_MISSING_EXEC_BIT=true \
+		-e DEFAULT_BRANCH=main \
 		-e USE_FIND_ALGORITHM=true \
 		-v "$(CURDIR)/.github":/tmp/lint \
 		$(SUPER_LINTER_TEST_CONTAINER_URL)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 all: info docker test ## Run all targets.
 
 .PHONY: test
-test: info validate-container-image-labels inspec ## Run tests
+test: info validate-container-image-labels inspec test-find ## Run tests
 
 # if this session isn't interactive, then we don't want to allocate a
 # TTY, which would fail, but if it is interactive, we do want to attach
@@ -104,3 +104,13 @@ validate-container-image-labels: ## Validate container image labels
 		$(BUILD_DATE) \
 		$(BUILD_REVISION) \
 		$(BUILD_VERSION)
+
+.phony: test-find
+test-find: ## Run super-linter on a subdirectory with USE_FIND_ALGORITHM=true
+	docker run \
+		-e RUN_LOCAL=true \
+		-e ACTIONS_RUNNER_DEBUG=true \
+		-e ERROR_ON_MISSING_EXEC_BIT=true \
+		-e USE_FIND_ALGORITHM=true \
+		-v "$(CURDIR)/.github":/tmp/lint \
+		$(SUPER_LINTER_TEST_CONTAINER_URL)

--- a/lib/functions/log.sh
+++ b/lib/functions/log.sh
@@ -54,7 +54,7 @@ export LOG_TEMP
 log() {
   local TOTERM=${1:-}
   local MESSAGE=${2:-}
-  local LOG_LEVEL_LABEL="[${3}]"
+  local LOG_LEVEL_LABEL="${3}"
 
   local LOG_MESSAGE_DATE
   LOG_MESSAGE_DATE="$(date +"%F %T")"
@@ -68,6 +68,8 @@ log() {
   elif [ "${LOG_LEVEL_LABEL}" == "ERROR" ] || [ "${LOG_LEVEL_LABEL}" == "FATAL" ]; then
     COLOR_MARKER="${F[R]}"
   fi
+
+  LOG_LEVEL_LABEL="[${LOG_LEVEL_LABEL}]"
 
   local COLORED_MESSAGE
   COLORED_MESSAGE="${NC}${LOG_MESSAGE_DATE} ${COLOR_MARKER}${LOG_LEVEL_LABEL}${NC}   ${MESSAGE}${NC}"

--- a/lib/functions/validation.sh
+++ b/lib/functions/validation.sh
@@ -235,6 +235,8 @@ function ValidateLocalGitRepository() {
 }
 
 function ValidateGitShaReference() {
+  debug "Git HEAD: $(git -C "${GITHUB_WORKSPACE}" show HEAD --stat)"
+
   debug "Validate that the GITHUB_SHA reference (${GITHUB_SHA}) exists in this Git repository."
   if ! git -C "${GITHUB_WORKSPACE}" cat-file -e "${GITHUB_SHA}"; then
     fatal "The GITHUB_SHA reference (${GITHUB_SHA}) doesn't exist in this Git repository"

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -468,6 +468,18 @@ GetGitHubVars() {
     pushd "${GITHUB_WORKSPACE}" >/dev/null || exit 1
 
     VALIDATE_ALL_CODEBASE="${DEFAULT_VALIDATE_ALL_CODEBASE}"
+
+    if [[ "${USE_FIND_ALGORITHM}" == "false" ]]; then
+      GITHUB_SHA=$(git -c "${GITHUB_WORKSPACE}" rev-parse HEAD)
+      ERROR_CODE=$?
+      debug "GITHUB_SHA initalization return code: ${ERROR_CODE}"
+      if [ ${ERROR_CODE} -ne 0 ]; then
+        fatal "Failed to initialize GITHUB_SHA. Output: ${GITHUB_SHA}"
+      fi
+      debug "GITHUB_SHA: ${GITHUB_SHA}"
+    else
+      debug "Skip the initalization of GITHUB_SHA because we don't need it"
+    fi
   else
     if [ -z "${GITHUB_WORKSPACE}" ]; then
       error "Failed to get [GITHUB_WORKSPACE]!"

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -443,6 +443,11 @@ Header() {
   info " - https://github.com/super-linter/super-linter"
   info "---------------------------------------------"
 }
+ConfigureGitSafeDirectories() {
+  debug "Allow Git to work on ${GITHUB_WORKSPACE}"
+  git config --global --add safe.directory "${GITHUB_WORKSPACE}" 2>&1
+  git config --global --add safe.directory "/tmp/lint" 2>&1
+}
 ################################################################################
 #### Function GetGitHubVars ####################################################
 GetGitHubVars() {
@@ -470,6 +475,7 @@ GetGitHubVars() {
     VALIDATE_ALL_CODEBASE="${DEFAULT_VALIDATE_ALL_CODEBASE}"
 
     if [[ "${USE_FIND_ALGORITHM}" == "false" ]]; then
+      ConfigureGitSafeDirectories
       GITHUB_SHA=$(git -c "${GITHUB_WORKSPACE}" rev-parse HEAD)
       ERROR_CODE=$?
       debug "GITHUB_SHA initalization return code: ${ERROR_CODE}"
@@ -836,9 +842,9 @@ GetLinterVersions
 # needed to connect back and update checks
 GetGitHubVars
 
-debug "Allow Git to work on ${GITHUB_WORKSPACE}"
-git config --global --add safe.directory "${GITHUB_WORKSPACE}" 2>&1
-git config --global --add safe.directory "/tmp/lint" 2>&1
+# Ensure that Git safe directories are configured because we don't do this in
+# all cases when initializing variables
+ConfigureGitSafeDirectories
 
 ########################################################
 # Initialize variables that depend on GitHub variables #

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -445,8 +445,7 @@ Header() {
 }
 ConfigureGitSafeDirectories() {
   declare -a git_safe_directories=("${GITHUB_WORKSPACE}" "/tmp/lint")
-  for safe_directory in "${git_safe_directories[@]}"
-  do
+  for safe_directory in "${git_safe_directories[@]}"; do
     debug "Allow Git to work on ${safe_directory}"
     if ! git config --global --add safe.directory "${safe_directory}"; then
       fatal "Cannot configure ${safe_directory} as a Git safe directory."

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -817,16 +817,16 @@ UpdateLoopsForImage
 ##################################
 GetLinterVersions
 
-debug "Allow Git to work on ${GITHUB_WORKSPACE}"
-git config --global --add safe.directory "${GITHUB_WORKSPACE}" 2>&1
-git config --global --add safe.directory "/tmp/lint" 2>&1
-
 #######################
 # Get GitHub Env Vars #
 #######################
 # Need to pull in all the GitHub variables
 # needed to connect back and update checks
 GetGitHubVars
+
+debug "Allow Git to work on ${GITHUB_WORKSPACE}"
+git config --global --add safe.directory "${GITHUB_WORKSPACE}" 2>&1
+git config --global --add safe.directory "/tmp/lint" 2>&1
 
 ########################################################
 # Initialize variables that depend on GitHub variables #

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -842,6 +842,8 @@ debug "TYPESCRIPT_STANDARD_TSCONFIG_FILE: ${TYPESCRIPT_STANDARD_TSCONFIG_FILE}"
 ############################
 # Validate the environment #
 ############################
+GetValidationInfo
+
 if [[ "${USE_FIND_ALGORITHM}" == "false" ]] || [[ "${VALIDATE_ALL_CODEBASE}" == "false" ]]; then
   debug "Validate the local Git environment"
   ValidateLocalGitRepository
@@ -850,8 +852,6 @@ if [[ "${USE_FIND_ALGORITHM}" == "false" ]] || [[ "${VALIDATE_ALL_CODEBASE}" == 
 else
   debug "Skipped the validation of the local Git environment because we don't depend on it."
 fi
-
-GetValidationInfo
 
 #################################
 # Get the linter rules location #

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -374,11 +374,11 @@ debug "IGNORE_GENERATED_FILES: ${IGNORE_GENERATED_FILES}"
 ################
 # Default Vars #
 ################
-DEFAULT_VALIDATE_ALL_CODEBASE='true'                # Default value for validate all files
-DEFAULT_SUPER_LINTER_WORKSPACE="/tmp/lint"
+DEFAULT_VALIDATE_ALL_CODEBASE='true'                                        # Default value for validate all files
+DEFAULT_SUPER_LINTER_WORKSPACE="/tmp/lint"                                  # Fall-back value for the workspace
 DEFAULT_WORKSPACE="${DEFAULT_WORKSPACE:-${DEFAULT_SUPER_LINTER_WORKSPACE}}" # Default workspace if running locally
-DEFAULT_RUN_LOCAL='false'                           # Default value for debugging locally
-DEFAULT_TEST_CASE_RUN='false'                       # Flag to tell code to run only test cases
+DEFAULT_RUN_LOCAL='false'                                                   # Default value for debugging locally
+DEFAULT_TEST_CASE_RUN='false'                                               # Flag to tell code to run only test cases
 
 if [ -z "${TEST_CASE_RUN}" ]; then
   TEST_CASE_RUN="${DEFAULT_TEST_CASE_RUN}"

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -842,7 +842,7 @@ debug "TYPESCRIPT_STANDARD_TSCONFIG_FILE: ${TYPESCRIPT_STANDARD_TSCONFIG_FILE}"
 ############################
 # Validate the environment #
 ############################
-if [[ "${USE_FIND_ALGORITHM}" != "false" ]] || [[ "${VALIDATE_ALL_CODEBASE}" != "true" ]]; then
+if [[ "${USE_FIND_ALGORITHM}" == "false" ]] || [[ "${VALIDATE_ALL_CODEBASE}" == "false" ]]; then
   debug "Validate the local Git environment"
   ValidateLocalGitRepository
   ValidateGitShaReference

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -844,7 +844,7 @@ debug "TYPESCRIPT_STANDARD_TSCONFIG_FILE: ${TYPESCRIPT_STANDARD_TSCONFIG_FILE}"
 ############################
 GetValidationInfo
 
-if [[ "${USE_FIND_ALGORITHM}" == "false" ]] || [[ "${VALIDATE_ALL_CODEBASE}" == "false" ]]; then
+if [[ "${USE_FIND_ALGORITHM}" == "false" ]]; then
   debug "Validate the local Git environment"
   ValidateLocalGitRepository
   ValidateGitShaReference

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -444,9 +444,14 @@ Header() {
   info "---------------------------------------------"
 }
 ConfigureGitSafeDirectories() {
-  debug "Allow Git to work on ${GITHUB_WORKSPACE}"
-  git config --global --add safe.directory "${GITHUB_WORKSPACE}" 2>&1
-  git config --global --add safe.directory "/tmp/lint" 2>&1
+  declare -a git_safe_directories=("${GITHUB_WORKSPACE}" "/tmp/lint")
+  for safe_directory in "${git_safe_directories[@]}"
+  do
+    debug "Allow Git to work on ${safe_directory}"
+    if ! git config --global --add safe.directory "${safe_directory}"; then
+      fatal "Cannot configure ${safe_directory} as a Git safe directory."
+    fi
+  done
 }
 ################################################################################
 #### Function GetGitHubVars ####################################################


### PR DESCRIPTION
<!-- Ensure that your PR title is brief and descriptive. -->
<!-- Start: issue fix section -->
<!-- Link to issue if there is one, otherwise remove the "issue fix" section -->
<!-- markdownlint-disable -->

Fixes #4952

<!-- markdownlint-restore -->
<!-- End: issue fix section -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Add a test case to run super-linter against a subdirectory after setting `USE_FIND_ALGORITHM=true`.
2. Move the configuration of `git safe.directory` after we set `GITHUB_WORKSPACE`, and not before because `GITHUB_WORKSPACE` might be initialized when running locally.
3. Validate variables before validating the Git repository, so that we get those variables initialized correctly before using them.
4. Validate the Git directory regardless of the value of `VALIDATE_ALL_CODEBASE` because we need a valid Git repository and references both when `VALIDATE_ALL_CODEBASE=true` and when `VALIDATE_ALL_CODEBASE=false`.
5. Validate the Git directory when `USE_FIND_ALGORITHM == false`, not when `USE_FIND_ALGORITHM != false`.
6. Initialize `GITHUB_SHA` when running locally and when `USE_FIND_ALGORITHM == false`.
7. Fail with a fatal error if we can't add the workspace to the list of safe Git directories.
8. Fix log level color markers for non-default cases.
9. Set `DEFAULT_BRANCH` when running tests.

## Readiness Checklist

### Author/Contributor

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.

### Reviewing Maintainer

- [x] Label as `breaking` if this is a large, fundamental change.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
