### PR TITLE
Populate the cache with the latest image

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -117,6 +117,7 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             BUILD_REVISION=${{ env.BUILD_REVISION }}
             BUILD_VERSION=${{ env.BUILD_VERSION }}
+          cache-from: type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}
           load: false
           push: true
           secrets: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             BUILD_REVISION=${{ env.BUILD_REVISION }}
             BUILD_VERSION=${{ env.BUILD_VERSION }}
+          cache-from: type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}
           load: true
           push: false
           secrets: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Pull the latest super-linter image from the registry
+        run: |
+          make docker-pull
+
+      - name: Print info about the system
+        run: |
+          make info
+
       - name: Build Image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,14 +77,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Pull the latest super-linter image from the registry
-        run: |
-          make docker-pull
-
-      - name: Print info about the system
-        run: |
-          make info
-
       - name: Build Image
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
## Proposed Changes

1. Populate the container image cache with the `latest` image to eventually speed up builds in case there are cache hits.

## Readiness Checklist

### Author/Contributor

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.

### Reviewing Maintainer

- [x] Label as `breaking` if this is a large, fundamental change.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
