### PR TITLE
Switch to tflint image because tflint-bundle is deprecated

### DIFF
--- a/.github/linters/.tflint.hcl
+++ b/.github/linters/.tflint.hcl
@@ -1,7 +1,0 @@
-config {
-  module = true
-}
-
-plugin "aws" {
-  enabled = true
-}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM alpine/terragrunt:1.6.5 as terragrunt
 FROM ghcr.io/assignuser/chktex-alpine:v0.2.0 as chktex
 FROM dotenvlinter/dotenv-linter:3.3.0 as dotenv-linter
 FROM ghcr.io/awkbar-devops/clang-format:v1.0.2 as clang-format
-FROM ghcr.io/terraform-linters/tflint-bundle:v0.48.0.0 as tflint
+FROM ghcr.io/terraform-linters/tflint:v0.48.0.0 as tflint
 FROM ghcr.io/yannh/kubeconform:v0.6.4 as kubeconfrm
 FROM golang:1.21.5-alpine as golang
 FROM golangci/golangci-lint:v1.55.2 as golangci-lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -338,7 +338,6 @@ COPY --from=base_image /lib/ /lib/
 COPY --from=base_image /bin/ /bin/
 COPY --from=base_image /node_modules/ /node_modules/
 COPY --from=base_image /home/r-library /home/r-library
-COPY --from=base_image /root/.tflint.d/ /root/.tflint.d/
 COPY --from=python_builder /venvs/ /venvs/
 
 ##################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM alpine/terragrunt:1.6.5 as terragrunt
 FROM ghcr.io/assignuser/chktex-alpine:v0.2.0 as chktex
 FROM dotenvlinter/dotenv-linter:3.3.0 as dotenv-linter
 FROM ghcr.io/awkbar-devops/clang-format:v1.0.2 as clang-format
-FROM ghcr.io/terraform-linters/tflint:v0.48.0.0 as tflint
+FROM ghcr.io/terraform-linters/tflint:v0.48.0 as tflint
 FROM ghcr.io/yannh/kubeconform:v0.6.4 as kubeconfrm
 FROM golang:1.21.5-alpine as golang
 FROM golangci/golangci-lint:v1.55.2 as golangci-lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,7 +130,6 @@ COPY --from=terraform /bin/terraform /usr/bin/
 # Install TFLint #
 ##################
 COPY --from=tflint /usr/local/bin/tflint /usr/bin/
-COPY --from=tflint /root/.tflint.d /root/.tflint.d
 
 #####################
 # Install Terrascan #

--- a/TEMPLATES/.tflint.hcl
+++ b/TEMPLATES/.tflint.hcl
@@ -4,6 +4,25 @@ config {
   force = false
 }
 
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
 plugin "aws" {
   enabled = true
+  version = "0.28.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
+plugin "azurerm" {
+  enabled = true
+  version = "0.25.1"
+  source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
+}
+
+plugin "google" {
+  enabled = true
+  version = "0.26.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-google"
 }

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -521,10 +521,10 @@ function RunAdditionalInstalls() {
     # Check the shell for errors #
     ##############################
     if [ "${ERROR_CODE}" -ne 0 ]; then
-      fatal "ERROR! Failed to run:[tflint --init] at location:[${WORKSPACE_PATH}]. BUILD_CMD:[${BUILD_CMD}]"
+      fatal "ERROR! Failed to initialize tflint with the ${TERRAFORM_TFLINT_LINTER_RULES} config file: ${BUILD_CMD}"
     else
-      info "Successfully ran:[tflint --init] in workspace:[${WORKSPACE_PATH}]"
-      debug "BUILD_CMD:[${BUILD_CMD}]"
+      info "Successfully initialized tflint with the ${TERRAFORM_TFLINT_LINTER_RULES} config file"
+      debug "Tflint output: ${BUILD_CMD}"
     fi
   fi
 }

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -504,18 +504,12 @@ function RunAdditionalInstalls() {
   if [ "${VALIDATE_TERRAFORM_TFLINT}" == "true" ] && [ "${#FILE_ARRAY_TERRAFORM_TFLINT[@]}" -ne 0 ]; then
     info "Detected TFLint Language files to lint."
     info "Trying to install the TFLint init inside:[${WORKSPACE_PATH}]"
-    # Set the log level
-    TF_LOG_LEVEL="info"
-    if [ "${ACTIONS_RUNNER_DEBUG}" = "true" ]; then
-      TF_LOG_LEVEL="debug"
-    fi
-    debug "Set the tflint log level to: ${TF_LOG_LEVEL}"
     #########################
     # Run the build command #
     #########################
     BUILD_CMD=$(
       cd "${WORKSPACE_PATH}" || exit 0
-      TFLINT_LOG="${TF_LOG_LEVEL}" tflint --init -c "${TERRAFORM_TFLINT_LINTER_RULES}" 2>&1
+      tflint --init -c "${TERRAFORM_TFLINT_LINTER_RULES}" 2>&1
     )
 
     ##############

--- a/lib/functions/worker.sh
+++ b/lib/functions/worker.sh
@@ -299,9 +299,9 @@ function LintCodebase() {
           cd "${WORKSPACE_PATH}" || exit
           RENOVATE_CONFIG_FILE="${FILE}" ${LINTER_COMMAND} 2>&1
         )
-      ############################################################################################
-      # Corner case for TERRAFORM_TFLINT as it cant use the full path and needs to fetch modules #
-      ############################################################################################
+      #############################################################################################
+      # Corner case for TERRAFORM_TFLINT as it can't use the full path and needs to fetch modules #
+      #############################################################################################
       elif [[ ${FILE_TYPE} == "TERRAFORM_TFLINT" ]]; then
         # Check the cache to see if we've already prepped this directory for tflint
         if [[ ! -v "TFLINT_SEEN_DIRS[${DIR_NAME}]" ]]; then

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -119,6 +119,17 @@ export VERSION_FILE                                       # Workaround SC2034
 
 debug "CREATE_LOG_FILE: ${CREATE_LOG_FILE}"
 
+# Set the log level
+TF_LOG_LEVEL="info"
+if [ "${ACTIONS_RUNNER_DEBUG}" = "true" ]; then
+  TF_LOG_LEVEL="debug"
+fi
+export TF_LOG_LEVEL
+debug "TF_LOG_LEVEL: ${TF_LOG_LEVEL}"
+TFLINT_LOG="${TF_LOG_LEVEL}"
+export TFLINT_LOG
+debug "TFLINT_LOG: ${TFLINT_LOG}"
+
 ###############
 # Rules files #
 ###############


### PR DESCRIPTION
## Proposed Changes

1. Switch from `tflint-bundle` to `tflint` because `tflint-bundle` is now deprecated.
2. Enable `azurerm` and `google` plugins by default.
3. Explicitly configure versions for plugins.
4. Define `TFLINT_LOG` and `TF_LOG_LEVEL` globally so we can reuse them anywhere we launch `tflint`.
5. Remove our tflint configuration file because the default is enough.

I didn't update tflint to the current latest version (`v0.49.0`) so we can see if dependabot picks it up.

## Readiness Checklist

### Author/Contributor

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.

### Reviewing Maintainer

- [x] Label as `breaking` if this is a large, fundamental change.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
