### PR TITLE
Simplify lintr installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -219,8 +219,8 @@ RUN --mount=type=secret,id=GITHUB_TOKEN /install-glibc.sh && rm -rf /install-gli
 #################
 # Install Lintr #
 #################
-COPY scripts/install-lintr.sh /
-RUN /install-lintr.sh && rm -rf /install-lintr.sh
+COPY scripts/install-lintr.sh scripts/install-r-package-or-fail.R /
+RUN /install-lintr.sh && rm -rf /install-lintr.sh /install-r-package-or-fail.R
 
 #################################
 # Install luacheck and luarocks #

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -479,7 +479,6 @@ function RunAdditionalInstalls() {
       ##############################
       INSTALL_CMD=$(
         cd "${WORKSPACE_PATH}" || exit 0
-        R -e "install.packages('remotes', repos = 'https://cloud.r-project.org/')" 2>&1
         R -e "remotes::install_local('.', dependencies=T)" 2>&1
       )
 

--- a/scripts/install-lintr.sh
+++ b/scripts/install-lintr.sh
@@ -2,8 +2,4 @@
 
 set -euo pipefail
 
-mkdir -p /home/r-library
-cp -r /usr/lib/R/library/ /home/r-library/
-Rscript -e "install.packages(c('lintr','purrr'), repos = 'https://cloud.r-project.org/')"
-R -e "install.packages(list.dirs('/home/r-library',recursive = FALSE), repos = NULL, type = 'source')"
-mv /etc/R/* /usr/lib/R/etc/
+Rscript --no-save /install-r-package-or-fail.R lintr purrr remotes

--- a/scripts/install-r-package-or-fail.R
+++ b/scripts/install-r-package-or-fail.R
@@ -1,0 +1,12 @@
+#!/usr/bin/env Rscript
+
+# Based on: https://stackoverflow.com/questions/26244530/how-do-i-make-install-packages-return-an-error-if-an-r-package-cannot-be-install
+
+packages = commandArgs(trailingOnly=TRUE)
+
+for (l in packages) {
+  install.packages(l, repos='https://cloud.r-project.org/');
+  if ( ! library(l, character.only=TRUE, logical.return=TRUE) ) {
+    quit(status=1, save='no')
+  }
+}

--- a/test/inspec/super-linter/controls/super_linter.rb
+++ b/test/inspec/super-linter/controls/super_linter.rb
@@ -402,7 +402,6 @@ control "super-linter-validate-directories" do
   desc "Check that directories that Super-Linter needs are installed."
 
   dirs = [
-    "/home/r-library",
     "/node_modules",
     "/action/lib",
     "/action/lib/functions",
@@ -413,7 +412,6 @@ control "super-linter-validate-directories" do
 
   # Removed linters from slim image
   SLIM_IMAGE_REMOVED_DIRS=%w(
-    /home/r-library
   )
 
   dirs.each do |item|


### PR DESCRIPTION
<!-- Ensure that your PR title is brief and descriptive. -->
<!-- Start: issue fix section -->
<!-- Link to issue if there is one, otherwise remove the "issue fix" section -->
<!-- markdownlint-disable -->

Fixes #4992

<!-- markdownlint-restore -->
<!-- End: issue fix section -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Fail if the installation of a R package fails.
2. Install the `remotes` package once during the image build, and not when we scan files at runtime.
3. Reuse the default R library directory instead of moving it to `/home/r-library/` and installing modules there.

## Readiness Checklist

### Author/Contributor

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.

### Reviewing Maintainer

- [x] Label as `breaking` if this is a large, fundamental change.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
