### PR TITLE
ci: don't validate dependabot commits

### DIFF
--- a/.github/linters/commitlint.config.js
+++ b/.github/linters/commitlint.config.js
@@ -1,4 +1,7 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
-  helpUrl: 'https://www.conventionalcommits.org/'
+  helpUrl: 'https://www.conventionalcommits.org/',
+  // We need this until https://github.com/dependabot/dependabot-core/issues/2445
+  // is resolved.
+  ignores: [(msg) => /Signed-off-by: dependabot\[bot]/m.test(msg)]
 }


### PR DESCRIPTION
## Proposed Changes

1. Dependabot doesn't allow configuring the max commit message line length until https://github.com/dependabot/dependabot-core/issues/2445 is resolved, so we cannot validate Dependabot commits at this time.

## Readiness Checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
