### PR TITLE
Use a base image and simplify environments

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "bootstrap-sha": "9db632f0e18a73a9845c11d0f35431e714a66772",
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,11 +21,9 @@ jobs:
       fail-fast: false
       matrix:
         images:
-          - environment: Production-SLIM
-            prefix: slim-
+          - prefix: slim-
             target: slim
-          - environment: Production
-            prefix: ""
+          - prefix: ""
             target: standard
     timeout-minutes: 60
     env:
@@ -101,13 +99,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Start ${{ matrix.images.environment }} Deployment
+      - name: Start deployment
         uses: bobheadxi/deployments@v1.4.0
         id: deployment
         with:
           step: start
           token: ${{ secrets.GITHUB_TOKEN }}
-          env: ${{ matrix.images.environment }}
+          env: Production
 
       - name: Build and Push Image
         uses: docker/build-push-action@v5
@@ -128,7 +126,7 @@ jobs:
             ${{ env.CONTAINER_IMAGE_ID }}
           target: "${{ matrix.images.target }}"
 
-      - name: Update ${{ matrix.images.environment }} Deployment
+      - name: Update deployment
         uses: bobheadxi/deployments@v1.4.0
         # We depend on the 'deployment' step outputs, so we can't run this step
         # if the 'deployment' step didn't run. This can happen if any step
@@ -173,8 +171,6 @@ jobs:
       issues: write
       packages: write
       pull-requests: write
-    env:
-      RELEASE_ENVIRONMENT: "Release"
     timeout-minutes: 60
     steps:
       - uses: google-github-actions/release-please-action@v4
@@ -191,7 +187,7 @@ jobs:
         with:
           step: start
           token: ${{ secrets.GITHUB_TOKEN }}
-          env: ${{ env.RELEASE_ENVIRONMENT }}
+          env: Release
 
       - name: Configure release metedata
         if: steps.release.outputs.release_created

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ FROM scalameta/scalafmt:v3.7.17 as scalafmt
 FROM zricethezav/gitleaks:v8.18.1 as gitleaks
 FROM yoheimuta/protolint:0.47.0 as protolint
 
-FROM python:3.12.1-alpine3.19 as slim
+FROM python:3.12.1-alpine3.19 as base_image
 
 LABEL com.github.actions.name="Super-Linter" \
     com.github.actions.description="A collection of code linters and analyzers." \
@@ -338,6 +338,8 @@ ENTRYPOINT ["/action/lib/linter.sh"]
 RUN terrascan init \
     && touch ~/.chktexrc
 
+FROM base_image as slim
+
 # Set build metadata here so we don't invalidate the container image cache if we
 # change the values of these arguments
 ARG BUILD_DATE
@@ -399,3 +401,17 @@ RUN --mount=type=secret,id=GITHUB_TOKEN /install-arm-ttk.sh && rm -rf /install-a
 
 # Run to build version file and validate image again because we installed more linters
 RUN ACTIONS_RUNNER_DEBUG=true WRITE_LINTER_VERSIONS_FILE=true IMAGE="${IMAGE}" /action/lib/linter.sh
+
+# Set build metadata here so we don't invalidate the container image cache if we
+# change the values of these arguments
+ARG BUILD_DATE
+ARG BUILD_REVISION
+ARG BUILD_VERSION
+
+LABEL org.opencontainers.image.created=$BUILD_DATE \
+    org.opencontainers.image.revision=$BUILD_REVISION \
+    org.opencontainers.image.version=$BUILD_VERSION
+
+ENV BUILD_DATE=$BUILD_DATE
+ENV BUILD_REVISION=$BUILD_REVISION
+ENV BUILD_VERSION=$BUILD_VERSION


### PR DESCRIPTION
## Proposed Changes

1. Refactor Dockerfile to use a base image so that we can reuse the cache for the standard image and not just the base image.
2. Simplify the cd workflow to take into account the Production environment only for latest images.

## Readiness Checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
