### PR TITLE
Update prefix for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     commit-message:
-      prefix: "build(github-actions)"
+      prefix: "deps(github-actions)"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -15,7 +15,7 @@ updates:
   # Maintain dependencies for js with npm
   - package-ecosystem: "npm"
     commit-message:
-      prefix: "build(npm)"
+      prefix: "deps(npm)"
     directory: "/dependencies"
     schedule:
       interval: "weekly"
@@ -24,7 +24,7 @@ updates:
   # Maintain dependencies for ruby with bundler
   - package-ecosystem: "bundler"
     commit-message:
-      prefix: "build(bundler)"
+      prefix: "deps(bundler)"
     directory: "/dependencies"
     schedule:
       interval: "weekly"
@@ -33,7 +33,7 @@ updates:
   # Maintain dependencies for docker
   - package-ecosystem: "docker"
     commit-message:
-      prefix: "build(docker)"
+      prefix: "deps(docker)"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -42,7 +42,7 @@ updates:
   # Maintain dependencies for python with pip
   - package-ecosystem: "pip"
     commit-message:
-      prefix: "build(python)"
+      prefix: "deps(python)"
     directory: "/dependencies/python/"
     schedule:
       interval: "weekly"
@@ -51,7 +51,7 @@ updates:
   # Maintain dependencies for Java
   - package-ecosystem: "gradle"
     commit-message:
-      prefix: "build(java)"
+      prefix: "deps(java)"
     directory: "/dependencies/checkstyle"
     schedule:
       interval: "weekly"
@@ -59,7 +59,7 @@ updates:
 
   - package-ecosystem: "gradle"
     commit-message:
-      prefix: "build(java)"
+      prefix: "deps(java)"
     directory: "/dependencies/google-java-format"
     schedule:
       interval: "weekly"
@@ -68,7 +68,7 @@ updates:
   # Maintain dev dependencies for docker
   - package-ecosystem: "docker"
     commit-message:
-      prefix: "build(dev-docker)"
+      prefix: "deps(dev-docker)"
     directory: "/dev-dependencies"
     schedule:
       interval: "weekly"
@@ -77,7 +77,7 @@ updates:
   # Maintain dev dependencies for js with npm
   - package-ecosystem: "npm"
     commit-message:
-      prefix: "build(dev-npm)"
+      prefix: "deps(dev-npm)"
     directory: "/dev-dependencies"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Proposed Changes

1. Use `deps` as the prefix for dependency updates.

## Readiness Checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
