### PR TITLE
Validate configuration when using USE_FIND_ALGORITHM and VALIDATE_ALL_CODEBASE

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -40,7 +40,19 @@ This section helps you migrate from super-linter `v5` to `v6`.
   information about how to ignore files with textlint, see
   [the textlint documentation](https://textlint.github.io/docs/ignore.html).
 
+### USE_FIND_ALGORITHM and VALIDATE_ALL_CODEBASE used together
+
+- Setting `USE_FIND_ALGORITHM` to `true` and `VALIDATE_ALL_CODEBASE` to `false`
+  is an unsupported configuration. super-linter `v5` and earlier silently
+  ignored `VALIDATE_ALL_CODEBASE` when `USE_FIND_ALGORITHM` is set to `true`,
+  leading to potentially confusing behavior for users. super-linter `v6`
+  explicitly fail in this case. Remove one of the two from your configuration,
+  depending on the desired behavior.
+
 ### VALIDATE_KOTLIN_ANDROID
 
-- The `VALIDATE_KOTLIN_ANDROID` variable has been deprecated. If you set it in
-  your configuration, change it to `VALIDATE_KOTLIN`.
+- The `VALIDATE_KOTLIN_ANDROID` variable has been deprecated because ktlint
+  handles linting Kotlin files for Android using a configuration option, so
+  super-linter doesn't need to account for this special case anymore. If you
+  set `VALIDATE_KOTLIN_ANDROID` in your configuration, change it to
+  `VALIDATE_KOTLIN` and configure ktlint to lint Android files.

--- a/lib/functions/validation.sh
+++ b/lib/functions/validation.sh
@@ -7,6 +7,10 @@ function GetValidationInfo() {
   info "--------------------------------------------"
   info "Gathering user validation information..."
 
+  if [[ "${USE_FIND_ALGORITHM}" == "true" ]] && [[ "${VALIDATE_ALL_CODEBASE}" == "false" ]]; then
+    fail "Setting USE_FIND_ALGORITHM to true and VALIDATE_ALL_CODEBASE to false is not supported because super-linter relies on Git to validate changed files."
+  fi
+
   ###########################################
   # Skip validation if were running locally #
   ###########################################


### PR DESCRIPTION
<!-- Start: issue fix section -->
<!-- Link to issue if there is one, otherwise remove the "issue fix" section -->
<!-- markdownlint-disable -->

Fixes #4956 

<!-- markdownlint-restore -->
<!-- End: issue fix section -->

## Proposed Changes

- Fail if the configuration contains `USE_FIND_ALGORITHM=true` and `VALIDATE_ALL_CODEBASE=false` because this is an unsupported configuration. Before this change, super-linter silently ignored `VALIDATE_ALL_CODEBASE`, leading to potentially surprising behavior.

## Readiness Checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
