### PR TITLE
Enable auto-merge for dependabot pull requests

### DIFF
--- a/.github/workflows/dependabot-automation.yaml
+++ b/.github/workflows/dependabot-automation.yaml
@@ -24,6 +24,7 @@ jobs:
         uses: dependabot/fetch-metadata@v1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Approve the PR
-        run: gh pr review --approve "${PR_URL}"
+      # This doesn't trigger an automated merge because we require at approvals
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash --delete-branch "${PR_URL}"
 ...


### PR DESCRIPTION
## Proposed Changes

- Enable auto-merge for DependaBot PRs. Enabling auto-merge doesn't actually merge these PRs because we still require approvals.

## Readiness Checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
