### PR TITLE
Install clj-kondo from its container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ FROM rhysd/actionlint:1.6.26 as actionlint
 FROM scalameta/scalafmt:v3.7.17 as scalafmt
 FROM zricethezav/gitleaks:v8.18.1 as gitleaks
 FROM yoheimuta/protolint:0.47.3 as protolint
+FROM ghcr.io/clj-kondo/clj-kondo:2023.05.18-alpine as clj-kondo
 
 FROM python:3.12.1-alpine3.19 as base_image
 
@@ -215,6 +216,11 @@ ARG GLIBC_VERSION
 COPY scripts/install-glibc.sh /
 RUN --mount=type=secret,id=GITHUB_TOKEN /install-glibc.sh && rm -rf /install-glibc.sh
 
+#####################
+# Install clj-kondo #
+#####################
+COPY --from=clj-kondo /bin/clj-kondo /usr/bin/
+
 #################
 # Install Lintr #
 #################
@@ -241,13 +247,6 @@ WORKDIR /
 ##############################
 COPY scripts/install-phive.sh /
 RUN /install-phive.sh && rm -rf /install-phive.sh
-
-#####################
-# Install clj-kondo #
-#####################
-ARG CLJ_KONDO_VERSION='2023.05.18'
-COPY scripts/install-clj-kondo.sh /
-RUN /install-clj-kondo.sh && rm -rf /install-clj-kondo.sh
 
 ##################
 # Install ktlint #

--- a/scripts/install-clj-kondo.sh
+++ b/scripts/install-clj-kondo.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-curl -sLO https://raw.githubusercontent.com/clj-kondo/clj-kondo/master/script/install-clj-kondo
-
-chmod +x install-clj-kondo
-
-./install-clj-kondo --dir /usr/bin/ --download-dir /usr/bin/ --version "${CLJ_KONDO_VERSION}"


### PR DESCRIPTION
<!-- Start: issue fix section -->
<!-- Link to issue if there is one, otherwise remove the "issue fix" section -->
<!-- markdownlint-disable -->

Related to #4986

<!-- markdownlint-restore -->
<!-- End: issue fix section -->

## Proposed Changes

Instead of providing a script to install clj-kondo, grab it from its container image so that we can benefit from automated dependency updates.

## Readiness Checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
