### PR TITLE
Install clang-format from OS package repo

### DIFF
--- a/test/inspec/super-linter/controls/super_linter.rb
+++ b/test/inspec/super-linter/controls/super_linter.rb
@@ -73,6 +73,7 @@ control "super-linter-uninstalled-packages" do
 
   packages = [
     "cmake",
+    "clang17-extra-tools",
     "g++",
     "gnupg",
     "libc-dev",


### PR DESCRIPTION
<!-- Start: issue fix section -->
<!-- Link to issue if there is one, otherwise remove the "issue fix" section -->
<!-- markdownlint-disable -->

Related to #4986

<!-- markdownlint-restore -->
<!-- End: issue fix section -->

## Proposed Changes

- Build and install clang-format instead of pulling it from a (potentially) unmaintained repository.

## Readiness Checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] If this is a breaking change, write upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
