### PR TITLE
Fix GITHUB_BEFORE_SHA initialization on push events

### DIFF
--- a/.github/pull_request-template.md
+++ b/.github/pull_request-template.md
@@ -1,19 +1,8 @@
-<!-- Start: issue fix section -->
-<!-- Link to issue if there is one, otherwise remove the "issue fix" section -->
-<!-- markdownlint-disable -->
+# Proposed changes
 
-Fixes #
+_describe the proposed changes and remove this template text_
 
-<!-- markdownlint-restore -->
-<!-- End: issue fix section -->
-
-## Proposed Changes
-
-- ...
-- ...
-- ...
-
-## Readiness Checklist
+## Readiness checklist
 
 In order to have this pull request merged, complete the following tasks.
 
@@ -23,7 +12,9 @@ In order to have this pull request merged, complete the following tasks.
 - [ ] I provided the necessary tests.
 - [ ] I squashed all the commits into a single commit.
 - [ ] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
-- [ ] If this is a breaking change, write upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
+- [ ] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
+- [ ] If this pull request is about and existing issue,
+  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.
 
 ### Super-linter maintainer tasks
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: Build and Test
 
 on:
   pull_request:
+  push:
   merge_group:
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ To run super-linter as a GitHub Action, you do the following:
         steps:
           - name: Checkout code
             uses: actions/checkout@v4
+            with:
+              # super-linter needs the full git history to get the
+              # list of files that changed across commits
+              fetch-depth: 0
 
           - name: Super-linter
             uses: super-linter/super-linter@v5.7.2  # x-release-please-version

--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 function IssueHintForFullGitHistory() {
-  info "Check that you have the full git history, the checkout is not shallow, etc"
+  info "Check that the local repository has the full history and that the repository is not shallow."
+  info "See https://github.com/super-linter/super-linter#get-started"
   info "Is shallow repository: $(git -C "${GITHUB_WORKSPACE}" rev-parse --is-shallow-repository)"
-  info "See https://github.com/super-linter/super-linter#example-connecting-github-action-workflow"
 }
 
 function GenerateFileDiff() {


### PR DESCRIPTION
## Proposed Changes

- Fix GITHUB_BEFORE_SHA initialization on push events by setting the
  correct key.
- Add an additional check against setting GITHUB_BEFORE_SHA to null.
- Run the CI workflow on push events to trigger required status checks
  when using the merge queue.

## Readiness Checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] If this is a breaking change, write upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
