### PR TITLE
Add event name to concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
         contents: read
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.images.target }}
+      group: ${{ github.workflow }}-${{ github.ref }}-{{ github.event_name }}-${{ matrix.images.target }}
       cancel-in-progress: true
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Proposed changes

In order to avoid unexpected workflow cancellations due to concurrency configuration, add the event name to the concurrency group.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
