### PR TITLE
Run versions command in the slim stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -394,12 +394,12 @@ COPY TEMPLATES /action/lib/.automation
 #################################
 COPY lib /action/lib
 
-# Run to build version file and validate image
-RUN ACTIONS_RUNNER_DEBUG=true WRITE_LINTER_VERSIONS_FILE=true IMAGE="${IMAGE}" /action/lib/linter.sh
-
 ENTRYPOINT ["/action/lib/linter.sh"]
 
 FROM base_image as slim
+
+# Run to build version file and validate image
+RUN ACTIONS_RUNNER_DEBUG=true WRITE_LINTER_VERSIONS_FILE=true IMAGE="${IMAGE}" /action/lib/linter.sh
 
 # Set build metadata here so we don't invalidate the container image cache if we
 # change the values of these arguments


### PR DESCRIPTION
# Proposed changes

Move the invocation of the command to build the linter versions file in the slim stage because we run it again in the standard stage anyway, so there's no need for the standard stage to wait for this command to run.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
