### PR TITLE
Simplify error code checks

### DIFF
--- a/lib/functions/githubEvent.sh
+++ b/lib/functions/githubEvent.sh
@@ -4,10 +4,9 @@ function GetGithubPushEventCommitCount() {
   local GITHUB_EVENT_FILE_PATH
   GITHUB_EVENT_FILE_PATH="${1}"
   local GITHUB_PUSH_COMMIT_COUNT
-  GITHUB_PUSH_COMMIT_COUNT=$(jq -r '.commits | length' <"${GITHUB_EVENT_FILE_PATH}")
-  ERROR_CODE=$?
-  if [ ${ERROR_CODE} -ne 0 ]; then
-    fatal "Failed to initialize GITHUB_PUSH_COMMIT_COUNT for a push event. Error code: ${ERROR_CODE}. Output: ${GITHUB_PUSH_COMMIT_COUNT}"
+
+  if ! GITHUB_PUSH_COMMIT_COUNT=$(jq -r '.commits | length' <"${GITHUB_EVENT_FILE_PATH}"); then
+    fatal "Failed to initialize GITHUB_PUSH_COMMIT_COUNT for a push event. Output: ${GITHUB_PUSH_COMMIT_COUNT}"
   fi
 
   if IsUnsignedInteger "${GITHUB_PUSH_COMMIT_COUNT}" && [ -n "${GITHUB_PUSH_COMMIT_COUNT}" ]; then

--- a/lib/functions/linterRules.sh
+++ b/lib/functions/linterRules.sh
@@ -194,22 +194,8 @@ GetStandardRules() {
   #########################################
   # Only env vars that are marked as true
   GET_ENV_ARRAY=()
-  if [[ ${LINTER} == "javascript" ]]; then
-    mapfile -t GET_ENV_ARRAY < <(yq .env "${JAVASCRIPT_STANDARD_LINTER_RULES}" | grep true)
-  fi
-
-  #######################
-  # Load the error code #
-  #######################
-  ERROR_CODE=$?
-
-  ##############################
-  # Check the shell for errors #
-  ##############################
-  if [ ${ERROR_CODE} -ne 0 ]; then
-    # ERROR
-    error "Failed to gain list of ENV vars to load!"
-    fatal "[${GET_ENV_ARRAY[*]}]"
+  if [[ ${LINTER} == "javascript" ]] && ! mapfile -t GET_ENV_ARRAY < <(yq .env "${JAVASCRIPT_STANDARD_LINTER_RULES}" | grep true); then
+    fatal "Failed to gain list of ENV vars to load: [${GET_ENV_ARRAY[*]}]"
   fi
 
   ##########################
@@ -218,14 +204,8 @@ GetStandardRules() {
   # Set IFS back to Orig
   IFS="${ORIG_IFS}"
 
-  ######################
-  # Set the env string #
-  ######################
   ENV_STRING=''
 
-  #############################
-  # Pull out the envs to load #
-  #############################
   for ENV in "${GET_ENV_ARRAY[@]}"; do
     #############################
     # remove spaces from return #

--- a/lib/functions/linterVersions.sh
+++ b/lib/functions/linterVersions.sh
@@ -16,7 +16,7 @@ GetLinterVersions() {
   fi
 
   if ! cat "${VERSION_FILE}"; then
-    fatal "Failed to view version file: ${VERSION_FILE}."
+    fatal "Failed to view version file: ${VERSION_FILE}"
   fi
 }
 ################################################################################


### PR DESCRIPTION
# Proposed changes

Instead of loading the error code and checking it, shorten checks by running the command directly.

There are a couple of instances of this pattern left in updateSSL that #5130 takes care of.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
