### PR TITLE
Build the file list and run linters in parallel

### DIFF
--- a/.github/linters/.checkov-test-linters-failure.yaml
+++ b/.github/linters/.checkov-test-linters-failure.yaml
@@ -1,5 +1,9 @@
 ---
 # Options reference: https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html
 
+directory:
+  - test/linters/checkov/bad
+
 quiet: false
+
 ...

--- a/.github/linters/.checkov-test-linters-success.yaml
+++ b/.github/linters/.checkov-test-linters-success.yaml
@@ -1,0 +1,8 @@
+---
+# Options reference: https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html
+
+directory:
+  - test/linters/checkov/good
+
+quiet: false
+...

--- a/.github/linters/.gitleaks-ignore-tests.toml
+++ b/.github/linters/.gitleaks-ignore-tests.toml
@@ -1,0 +1,13 @@
+
+title = "gitleaks config"
+
+[extend]
+# useDefault will extend the base configuration with the default gitleaks config:
+# https://github.com/zricethezav/gitleaks/blob/master/config/gitleaks.toml
+useDefault = true
+
+[allowlist]
+description = "Allow secrets in test files"
+paths = [
+  '''.*/test/linters/gitleaks/bad/.*'''
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main
+          GITLEAKS_CONFIG_FILE: .gitleaks-ignore-tests.toml
           RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES: "default.json,hoge.json"
           TYPESCRIPT_STANDARD_TSCONFIG_FILE: ".github/linters/tsconfig.json"
 

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,9 @@ super-linter.report
 # Code coverage data for tests
 .coverage
 
+# Terraform workspace
+.terraform
+
 # Test reports
 test/reports
 

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,9 +1,0 @@
-.github-personal-access-token:github-fine-grained-pat:1
-/github/workspace/.github-personal-access-token:github-fine-grained-pat:1
-/github/workspace/test/linters/gitleaks/bad/gitleaks_bad_01.txt:aws-access-token:1
-/github/workspace/test/linters/gitleaks/bad/gitleaks_bad_01.txt:generic-api-key:2
-/tmp/lint/.github-personal-access-token:github-fine-grained-pat:1
-/tmp/lint/test/linters/gitleaks/bad/gitleaks_bad_01.txt:aws-access-token:1
-/tmp/lint/test/linters/gitleaks/bad/gitleaks_bad_01.txt:generic-api-key:2
-test/linters/gitleaks/bad/gitleaks_bad_01.txt:aws-access-token:1
-test/linters/gitleaks/bad/gitleaks_bad_01.txt:generic-api-key:2

--- a/Dockerfile
+++ b/Dockerfile
@@ -134,6 +134,7 @@ RUN apk add --no-cache \
     nodejs-current \
     openjdk17-jre \
     openssh-client \
+    parallel \
     perl \
     php82 \
     php82-ctype \

--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ test-git-flags: ## Run super-linter with different git-related flags
 		-e ACTIONS_RUNNER_DEBUG=true \
 		-e ERROR_ON_MISSING_EXEC_BIT=true \
 		-e ENABLE_GITHUB_ACTIONS_GROUP_TITLE=true \
+		-e FILTER_REGEX_EXCLUDE=".*/test/linters/.*" \
 		-e DEFAULT_BRANCH=main \
 		-e IGNORE_GENERATED_FILES=true \
 		-e IGNORE_GITIGNORED_FILES=true \
@@ -178,6 +179,8 @@ lint-codebase: ## Lint the entire codebase
 		-e ACTIONS_RUNNER_DEBUG=true \
 		-e DEFAULT_BRANCH=main \
 		-e ENABLE_GITHUB_ACTIONS_GROUP_TITLE=true \
+		-e FILTER_REGEX_EXCLUDE=".*/test/linters/.*" \
+		-e GITLEAKS_CONFIG_FILE=".gitleaks-ignore-tests.toml" \
 		-e RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES="default.json,hoge.json" \
 		-e VALIDATE_ALL_CODEBASE=true \
 		-v "$(CURDIR):/tmp/lint" \
@@ -195,6 +198,7 @@ lint-subset-files-enable-only-one-type: ## Lint a small subset of files in the c
 		-e ACTIONS_RUNNER_DEBUG=true \
 		-e DEFAULT_BRANCH=main \
 		-e ENABLE_GITHUB_ACTIONS_GROUP_TITLE=true \
+		-e FILTER_REGEX_EXCLUDE=".*/test/linters/.*" \
 		-e VALIDATE_ALL_CODEBASE=true \
 		-e VALIDATE_MARKDOWN=true \
 		-v "$(CURDIR):/tmp/lint" \
@@ -207,6 +211,7 @@ lint-subset-files-enable-expensive-io-checks: ## Lint a small subset of files in
 		-e ACTIONS_RUNNER_DEBUG=true \
 		-e DEFAULT_BRANCH=main \
 		-e ENABLE_GITHUB_ACTIONS_GROUP_TITLE=true \
+		-e FILTER_REGEX_EXCLUDE=".*/test/linters/.*" \
 		-e VALIDATE_ALL_CODEBASE=true \
 		-e VALIDATE_ARM=true \
 		-e VALIDATE_CLOUDFORMATION=true \
@@ -272,19 +277,19 @@ test-custom-ssl-cert: ## Test the configuration of a custom SSL/TLS certificate
 		$(SUPER_LINTER_TEST_CONTAINER_URL)
 
 .phony: test-linters
-test-linters: ## Run the linters test suite
-	docker run \
-		-e ACTIONS_RUNNER_DEBUG=true \
-		-e CHECKOV_FILE_NAME=".checkov-test-linters.yaml" \
-		-e DEFAULT_BRANCH=main \
-		-e ENABLE_GITHUB_ACTIONS_GROUP_TITLE=true \
-		-e JSCPD_CONFIG_FILE=".jscpd-test-linters.json" \
-		-e RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES="default.json,hoge.json" \
-		-e RUN_LOCAL=true \
-		-e TEST_CASE_RUN=true \
-		-e TYPESCRIPT_STANDARD_TSCONFIG_FILE=".github/linters/tsconfig.json" \
-		-v "$(CURDIR):/tmp/lint" \
-		$(SUPER_LINTER_TEST_CONTAINER_URL)
+test-linters: test-linters-expect-success test-linters-expect-failure ## Run the linters test suite
+
+.phony: test-linters-expect-success
+test-linters-expect-success: ## Run the linters test suite expecting successes
+	$(CURDIR)/test/run-super-linter-tests.sh \
+		$(SUPER_LINTER_TEST_CONTAINER_URL) \
+		"run_test_cases_expect_success"
+
+.phony: test-linters-expect-failure
+test-linters-expect-failure: ## Run the linters test suite expecting failures
+	$(CURDIR)/test/run-super-linter-tests.sh \
+		$(SUPER_LINTER_TEST_CONTAINER_URL) \
+		"run_test_cases_expect_failure"
 
 .phony: build-dev-container-image
 build-dev-container-image: ## Build commit linter container image

--- a/docs/add-new-linter.md
+++ b/docs/add-new-linter.md
@@ -90,6 +90,7 @@ new tool, it should include:
 - Update the orchestration scripts to run the new tool:
 
   - `lib/linter.sh`
+  - `lib/functions/linterCommands.sh`
   - Provide the logic to populate the list of files or directories to examine: `lib/buildFileList.sh`
   - If necessary, provide elaborate logic to detect if the tool should examine a file or a directory: `lib/detectFiles.sh`
   - If the tool needs to take into account special cases:

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -52,10 +52,6 @@ This section helps you migrate from super-linter `v5` to `v6`.
 - If you defined secret patterns in `.gitleaks.toml`, Gitleaks may report errors
   about that file. If this happens, you can
   [configure Gitleaks to ignore that file](https://github.com/gitleaks/gitleaks/tree/master?tab=readme-ov-file#gitleaksignore).
-- Gitleaks doesn't consider the `FILTER_REGEX_EXCLUDE`, `FILTER_REGEX_INCLUDE`,
-  `IGNORE_GENERATED_FILES`, `IGNORE_GITIGNORED_FILES` variables. For more
-  information about how to ignore files with Gitleaks, see
-  [the Gitleaks documentation](https://github.com/gitleaks/gitleaks/tree/master?tab=readme-ov-file#gitleaksignore).
 
 ### Jscpd
 

--- a/lib/functions/linterCommands.sh
+++ b/lib/functions/linterCommands.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+##########################
+# Define linter commands #
+##########################
+
+# If there's no input argument, parallel adds a default {} at the end of the command.
+# In a few cases, such as ANSIBLE and GO_MODULES,
+# Consume the input before running the command because we need the input
+# to set the working directory, but we don't need it appended at the end of the command.
+# Setting -n 0 would not help in this case, because the input will not be passed
+# to the --workdir option as well.
+# shellcheck disable=SC2034 # Variable is referenced in other scripts
+LINTER_COMMANDS_ARRAY_ANSIBLE=(ansible-lint -c "${ANSIBLE_LINTER_RULES}" "&& echo \"Linted: {}\"")
+LINTER_COMMANDS_ARRAY_ARM=(pwsh -NoProfile -NoLogo -Command "\"Import-Module ${ARM_TTK_PSD1} ; \\\${config} = \\\$(Import-PowerShellDataFile -Path ${ARM_LINTER_RULES}) ; Test-AzTemplate @config -TemplatePath '{}'; if (\\\${Error}.Count) { exit 1 }\"")
+LINTER_COMMANDS_ARRAY_BASH=(shellcheck --color --external-sources)
+if [ -n "${BASH_SEVERITY}" ]; then
+  LINTER_COMMANDS_ARRAY_BASH+=(--severity="${BASH_SEVERITY}")
+fi
+LINTER_COMMANDS_ARRAY_BASH_EXEC=(bash-exec)
+LINTER_COMMANDS_ARRAY_CHECKOV=(checkov --config-file "${CHECKOV_LINTER_RULES}")
+if CheckovConfigurationFileContainsDirectoryOption "${CHECKOV_LINTER_RULES}"; then
+  # Consume the input as we do with ANSIBLE
+  debug "Consume the input of the Checkov command because we don't need to add it as an argument."
+  LINTER_COMMANDS_ARRAY_CHECKOV+=("&& echo \"Got the list of directories to lint from the configuration file: {}\"")
+else
+  debug "Adding the '--directory' option to the Checkov command."
+  LINTER_COMMANDS_ARRAY_CHECKOV+=(--directory)
+fi
+LINTER_COMMANDS_ARRAY_CLANG_FORMAT=(clang-format --Werror --dry-run)
+LINTER_COMMANDS_ARRAY_CLOJURE=(clj-kondo --config "${CLOJURE_LINTER_RULES}" --lint)
+LINTER_COMMANDS_ARRAY_CLOUDFORMATION=(cfn-lint --config-file "${CLOUDFORMATION_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_COFFEESCRIPT=(coffeelint -f "${COFFEESCRIPT_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_CPP=(cpplint)
+LINTER_COMMANDS_ARRAY_CSHARP=(dotnet format whitespace --folder --verify-no-changes --exclude / --include "{/}")
+LINTER_COMMANDS_ARRAY_CSS=(stylelint --config "${CSS_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_DART=(dart analyze --fatal-infos --fatal-warnings)
+LINTER_COMMANDS_ARRAY_DOCKERFILE_HADOLINT=(hadolint -c "${DOCKERFILE_HADOLINT_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_EDITORCONFIG=(editorconfig-checker -config "${EDITORCONFIG_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_ENV=(dotenv-linter)
+LINTER_COMMANDS_ARRAY_GITHUB_ACTIONS=(actionlint -config-file "${GITHUB_ACTIONS_LINTER_RULES}")
+if [ "${GITHUB_ACTIONS_COMMAND_ARGS}" != "null" ] && [ -n "${GITHUB_ACTIONS_COMMAND_ARGS}" ]; then
+  LINTER_COMMANDS_ARRAY_GITHUB_ACTIONS+=("${GITHUB_ACTIONS_COMMAND_ARGS}")
+fi
+LINTER_COMMANDS_ARRAY_GITLEAKS=(gitleaks detect --no-banner --no-git --redact --config "${GITLEAKS_LINTER_RULES}" --verbose --source)
+LINTER_COMMANDS_ARRAY_GHERKIN=(gherkin-lint -c "${GHERKIN_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_GO=(golangci-lint run -c "${GO_LINTER_RULES}" --fast)
+# Consume the input as we do with ANSIBLE
+LINTER_COMMANDS_ARRAY_GO_MODULES=(golangci-lint run --allow-parallel-runners -c "${GO_LINTER_RULES}" "&& echo \"Linted: {}\"")
+LINTER_COMMANDS_ARRAY_GOOGLE_JAVA_FORMAT=(java -jar /usr/bin/google-java-format --dry-run --set-exit-if-changed)
+LINTER_COMMANDS_ARRAY_GROOVY=(npm-groovy-lint -c "${GROOVY_LINTER_RULES}" --failon warning --no-insight)
+LINTER_COMMANDS_ARRAY_HTML=(htmlhint --config "${HTML_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_JAVA=(java -jar /usr/bin/checkstyle -c "${JAVA_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_JAVASCRIPT_ES=(eslint --no-eslintrc -c "${JAVASCRIPT_ES_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_JAVASCRIPT_STANDARD=(standard "${JAVASCRIPT_STANDARD_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_JAVASCRIPT_PRETTIER=(prettier --check)
+LINTER_COMMANDS_ARRAY_JSCPD=(jscpd --config "${JSCPD_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_JSON=(eslint --no-eslintrc -c "${JAVASCRIPT_ES_LINTER_RULES}" --ext '.json')
+LINTER_COMMANDS_ARRAY_JSONC=(eslint --no-eslintrc -c "${JAVASCRIPT_ES_LINTER_RULES}" --ext '.json5,.jsonc')
+LINTER_COMMANDS_ARRAY_JSX=(eslint --no-eslintrc -c "${JSX_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_KOTLIN=(ktlint "{/}")
+LINTER_COMMANDS_ARRAY_KUBERNETES_KUBECONFORM=(kubeconform -strict)
+if [ "${KUBERNETES_KUBECONFORM_OPTIONS}" != "null" ] && [ -n "${KUBERNETES_KUBECONFORM_OPTIONS}" ]; then
+  LINTER_COMMANDS_ARRAY_KUBERNETES_KUBECONFORM+=("${KUBERNETES_KUBECONFORM_OPTIONS}")
+fi
+LINTER_COMMANDS_ARRAY_LATEX=(chktex -q -l "${LATEX_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_LUA=(luacheck --config "${LUA_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_MARKDOWN=(markdownlint -c "${MARKDOWN_LINTER_RULES}")
+if [ -n "${MARKDOWN_CUSTOM_RULE_GLOBS}" ]; then
+  IFS="," read -r -a MARKDOWN_CUSTOM_RULE_GLOBS_ARRAY <<<"${MARKDOWN_CUSTOM_RULE_GLOBS}"
+  for glob in "${MARKDOWN_CUSTOM_RULE_GLOBS_ARRAY[@]}"; do
+    if [ -z "${LINTER_RULES_PATH}" ]; then
+      LINTER_COMMANDS_ARRAY_MARKDOWN+=(-r "${GITHUB_WORKSPACE}/${glob}")
+    else
+      LINTER_COMMANDS_ARRAY_MARKDOWN+=(-r "${GITHUB_WORKSPACE}/${LINTER_RULES_PATH}/${glob}")
+    fi
+  done
+fi
+LINTER_COMMANDS_ARRAY_NATURAL_LANGUAGE=(textlint -c "${NATURAL_LANGUAGE_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_OPENAPI=(spectral lint -r "${OPENAPI_LINTER_RULES}" -D)
+LINTER_COMMANDS_ARRAY_PERL=(perlcritic)
+if [ "${PERL_PERLCRITIC_OPTIONS}" != "null" ] && [ -n "${PERL_PERLCRITIC_OPTIONS}" ]; then
+  LINTER_COMMANDS_ARRAY_PERL+=("${PERL_PERLCRITIC_OPTIONS}")
+fi
+LINTER_COMMANDS_ARRAY_PHP_BUILTIN=(php -l -c "${PHP_BUILTIN_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_PHP_PHPCS=(phpcs --standard="${PHP_PHPCS_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_PHP_PHPSTAN=(phpstan analyse --no-progress --no-ansi --memory-limit 1G -c "${PHP_PHPSTAN_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_PHP_PSALM=(psalm --config="${PHP_PSALM_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_POWERSHELL=(pwsh -NoProfile -NoLogo -Command "\"Invoke-ScriptAnalyzer -EnableExit -Settings ${POWERSHELL_LINTER_RULES} -Path '{}'; if (\\\${Error}.Count) { exit 1 }\"")
+LINTER_COMMANDS_ARRAY_PROTOBUF=(protolint lint --config_path "${PROTOBUF_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_PYTHON_BLACK=(black --config "${PYTHON_BLACK_LINTER_RULES}" --diff --check)
+LINTER_COMMANDS_ARRAY_PYTHON_PYLINT=(pylint --rcfile "${PYTHON_PYLINT_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_PYTHON_FLAKE8=(flake8 --config="${PYTHON_FLAKE8_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_PYTHON_ISORT=(isort --check --diff --sp "${PYTHON_ISORT_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_PYTHON_MYPY=(mypy --config-file "${PYTHON_MYPY_LINTER_RULES}" --install-types --non-interactive)
+LINTER_COMMANDS_ARRAY_R=(R --slave -e "\"lints <- lintr::lint('{}');print(lints);errors <- purrr::keep(lints, ~ .\\\$type == 'error');quit(save = 'no', status = if (length(errors) > 0) 1 else 0)\"")
+LINTER_COMMANDS_ARRAY_RAKU=(raku)
+LINTER_COMMANDS_ARRAY_RENOVATE=(renovate-config-validator --strict)
+LINTER_COMMANDS_ARRAY_RUBY=(rubocop -c "${RUBY_LINTER_RULES}" --force-exclusion --ignore-unrecognized-cops)
+LINTER_COMMANDS_ARRAY_RUST_2015=(rustfmt --check --edition 2015)
+LINTER_COMMANDS_ARRAY_RUST_2018=(rustfmt --check --edition 2018)
+LINTER_COMMANDS_ARRAY_RUST_2021=(rustfmt --check --edition 2021)
+LINTER_COMMANDS_ARRAY_RUST_CLIPPY=(clippy)
+LINTER_COMMANDS_ARRAY_SCALAFMT=(scalafmt --config "${SCALAFMT_LINTER_RULES}" --test)
+LINTER_COMMANDS_ARRAY_SHELL_SHFMT=(shfmt -d)
+LINTER_COMMANDS_ARRAY_SNAKEMAKE_LINT=(snakemake --lint -s)
+LINTER_COMMANDS_ARRAY_SNAKEMAKE_SNAKEFMT=(snakefmt --config "${SNAKEMAKE_SNAKEFMT_LINTER_RULES}" --check --compact-diff)
+LINTER_COMMANDS_ARRAY_STATES=(asl-validator --json-path)
+LINTER_COMMANDS_ARRAY_SQL=(sql-lint --config "${SQL_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_SQLFLUFF=(sqlfluff lint --config "${SQLFLUFF_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_TEKTON=(tekton-lint)
+LINTER_COMMANDS_ARRAY_TERRAFORM_FMT=(terraform fmt -check -diff)
+LINTER_COMMANDS_ARRAY_TERRAFORM_TFLINT=("TF_DATA_DIR=\"/tmp/.terraform-TERRAFORM_TFLINT-{//}\"" tflint -c "${TERRAFORM_TFLINT_LINTER_RULES}" "--filter=\"{/}\"")
+LINTER_COMMANDS_ARRAY_TERRAFORM_TERRASCAN=(terrascan scan -i terraform -t all -c "${TERRAFORM_TERRASCAN_LINTER_RULES}" -f)
+LINTER_COMMANDS_ARRAY_TERRAGRUNT=(terragrunt hclfmt --terragrunt-check --terragrunt-log-level error --terragrunt-hclfmt-file)
+LINTER_COMMANDS_ARRAY_TSX=(eslint --no-eslintrc -c "${TSX_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_TYPESCRIPT_ES=(eslint --no-eslintrc -c "${TYPESCRIPT_ES_LINTER_RULES}")
+LINTER_COMMANDS_ARRAY_TYPESCRIPT_STANDARD=(ts-standard --parser @typescript-eslint/parser --plugin @typescript-eslint/eslint-plugin --project "${TYPESCRIPT_STANDARD_TSCONFIG_FILE}")
+LINTER_COMMANDS_ARRAY_TYPESCRIPT_PRETTIER=(prettier --check)
+LINTER_COMMANDS_ARRAY_XML=(xmllint)
+LINTER_COMMANDS_ARRAY_YAML=(yamllint -c "${YAML_LINTER_RULES}" -f parsable)
+if [ "${YAML_ERROR_ON_WARNING}" == 'true' ]; then
+  LINTER_COMMANDS_ARRAY_YAML+=(--strict)
+fi

--- a/lib/functions/log.sh
+++ b/lib/functions/log.sh
@@ -98,8 +98,11 @@ fatal() {
 
 # shellcheck disable=SC2034  # Variable is referenced in other files
 SUPER_LINTER_INITIALIZATION_LOG_GROUP_TITLE="Super-Linter initialization"
+export SUPER_LINTER_INITIALIZATION_LOG_GROUP_TITLE
 GITHUB_ACTIONS_LOG_GROUP_MARKER_START="start"
+export GITHUB_ACTIONS_LOG_GROUP_MARKER_START
 GITHUB_ACTIONS_LOG_GROUP_MARKER_END="end"
+export GITHUB_ACTIONS_LOG_GROUP_MARKER_END
 
 writeGitHubActionsLogGroupMarker() {
   local LOG_GROUP_MARKER_MODE="${1}"
@@ -139,3 +142,16 @@ startGitHubActionsLogGroup() {
 endGitHubActionsLogGroup() {
   writeGitHubActionsLogGroupMarker "${GITHUB_ACTIONS_LOG_GROUP_MARKER_END}" "${1}"
 }
+
+# We need these functions to be available when using parallel to run subprocesses
+export -f debug
+export -f endGitHubActionsLogGroup
+export -f error
+export -f fatal
+export -f info
+export -f log
+export -f notice
+export -f startGitHubActionsLogGroup
+export -f trace
+export -f warn
+export -f writeGitHubActionsLogGroupMarker

--- a/lib/functions/validation.sh
+++ b/lib/functions/validation.sh
@@ -13,11 +13,11 @@ function ValidateBooleanConfigurationVariables() {
   ValidateBooleanVariable "SSH_SETUP_GITHUB" "${SSH_SETUP_GITHUB}"
   ValidateBooleanVariable "SUPPRESS_FILE_TYPE_WARN" "${SUPPRESS_FILE_TYPE_WARN}"
   ValidateBooleanVariable "SUPPRESS_POSSUM" "${SUPPRESS_POSSUM}"
-  ValidateBooleanVariable "USE_FIND_ALGORITHM" "${USE_FIND_ALGORITHM}"
   ValidateBooleanVariable "TEST_CASE_RUN" "${TEST_CASE_RUN}"
+  ValidateBooleanVariable "USE_FIND_ALGORITHM" "${USE_FIND_ALGORITHM}"
   ValidateBooleanVariable "VALIDATE_ALL_CODEBASE" "${VALIDATE_ALL_CODEBASE}"
-  ValidateBooleanVariable "YAML_ERROR_ON_WARNING" "${YAML_ERROR_ON_WARNING}"
   ValidateBooleanVariable "WRITE_LINTER_VERSIONS_FILE" "${WRITE_LINTER_VERSIONS_FILE}"
+  ValidateBooleanVariable "YAML_ERROR_ON_WARNING" "${YAML_ERROR_ON_WARNING}"
 }
 
 function ValidateGitHubWorkspace() {
@@ -100,14 +100,6 @@ function GetValidationInfo() {
     VALIDATE_LANGUAGE="VALIDATE_${LANGUAGE}"
     if [[ ${!VALIDATE_LANGUAGE} == "true" ]]; then
       debug "- Validating [${LANGUAGE}] files in code base..."
-
-      debug "Defining variables for ${LANGUAGE} linter..."
-
-      ERRORS_VARIABLE_NAME="ERRORS_FOUND_${LANGUAGE}"
-      debug "Setting ${ERRORS_VARIABLE_NAME} variable value to 0..."
-      eval "${ERRORS_VARIABLE_NAME}=0"
-      debug "Exporting ${ERRORS_VARIABLE_NAME} variable..."
-      eval "export ${ERRORS_VARIABLE_NAME}"
     else
       debug "- Excluding [$LANGUAGE] files in code base..."
     fi
@@ -139,10 +131,6 @@ function GetValidationInfo() {
     ANSIBLE_DIRECTORY="${TEMP_ANSIBLE_DIRECTORY}"
     debug "Setting Ansible directory to: ${ANSIBLE_DIRECTORY}"
   fi
-
-  debug "Runner: $(id -un 2>/dev/null)"
-  debug "ENV:"
-  debug "$(printenv | sort)"
 }
 
 function CheckIfGitBranchExists() {
@@ -170,6 +158,7 @@ function ValidateBooleanVariable() {
     debug "${VAR_NAME} has a valid boolean string value: ${VAR_VALUE}"
   fi
 }
+export -f ValidateBooleanVariable
 
 function ValidateLocalGitRepository() {
   debug "Check if ${GITHUB_WORKSPACE} is a Git repository"
@@ -251,6 +240,10 @@ function CheckovConfigurationFileContainsDirectoryOption() {
   local CONFIGURATION_OPTION_KEY="directory:"
   debug "Checking if ${CHECKOV_LINTER_RULES_PATH} contains a '${CONFIGURATION_OPTION_KEY}' configuration option"
 
+  if [ ! -e "${CHECKOV_LINTER_RULES_PATH}" ]; then
+    fatal "${CHECKOV_LINTER_RULES_PATH} doesn't exist. Cannot check if it contains a '${CONFIGURATION_OPTION_KEY}' configuration option"
+  fi
+
   if grep -q "${CONFIGURATION_OPTION_KEY}" "${CHECKOV_LINTER_RULES_PATH}"; then
     debug "${CHECKOV_LINTER_RULES_PATH} contains a '${CONFIGURATION_OPTION_KEY}' statement"
     return 0
@@ -259,6 +252,7 @@ function CheckovConfigurationFileContainsDirectoryOption() {
     return 1
   fi
 }
+export -f CheckovConfigurationFileContainsDirectoryOption
 
 function WarnIfVariableIsSet() {
   local INPUT_VARIABLE="${1}"

--- a/lib/functions/worker.sh
+++ b/lib/functions/worker.sh
@@ -1,213 +1,218 @@
 #!/usr/bin/env bash
 
 function LintCodebase() {
+  local FILE_TYPE
   FILE_TYPE="${1}" && shift
-  LINTER_NAME="${1}" && shift
-  LINTER_COMMAND="${1}" && shift
-  FILTER_REGEX_INCLUDE="${1}" && shift
-  FILTER_REGEX_EXCLUDE="${1}" && shift
+  local TEST_CASE_RUN
   TEST_CASE_RUN="${1}" && shift
-  FILE_ARRAY=("$@")
 
-  # Array to track directories where tflint was run
-  declare -A TFLINT_SEEN_DIRS
+  declare -n VALIDATE_LANGUAGE
+  VALIDATE_LANGUAGE="VALIDATE_${FILE_TYPE}"
+
+  if [[ "${VALIDATE_LANGUAGE}" == "false" ]]; then
+    if [[ "${TEST_CASE_RUN}" == "false" ]]; then
+      debug "Skip validation of ${FILE_TYPE} because VALIDATE_LANGUAGE is ${VALIDATE_LANGUAGE}"
+      unset -n VALIDATE_LANGUAGE
+      return 0
+    else
+      fatal "Don't disable any validation when running in test mode. VALIDATE_${FILE_TYPE} is set to: ${VALIDATE_LANGUAGE}. Set it to: true"
+    fi
+  fi
+
+  debug "Running LintCodebase. FILE_TYPE: ${FILE_TYPE}. TEST_CASE_RUN: ${TEST_CASE_RUN}"
+
+  debug "VALIDATE_LANGUAGE for ${FILE_TYPE}: ${VALIDATE_LANGUAGE}..."
+
+  ValidateBooleanVariable "TEST_CASE_RUN" "${TEST_CASE_RUN}"
+  ValidateBooleanVariable "VALIDATE_${FILE_TYPE}" "${VALIDATE_LANGUAGE}"
+
+  unset -n VALIDATE_LANGUAGE
+
+  debug "Populating file array for ${FILE_TYPE}"
+  local -n FILE_ARRAY="FILE_ARRAY_${FILE_TYPE}"
+  local FILE_ARRAY_LANGUAGE_PATH="${FILE_ARRAYS_DIRECTORY_PATH}/file-array-${FILE_TYPE}"
+  if [[ -e "${FILE_ARRAY_LANGUAGE_PATH}" ]]; then
+    while read -r FILE; do
+      if [[ "${TEST_CASE_RUN}" == "true" ]]; then
+        debug "Ensure that the list files to check for ${FILE_TYPE} doesn't include test cases for other languages"
+        # Folder for specific tests. By convention, the last part of the path is the lowercased FILE_TYPE
+        local TEST_CASE_DIRECTORY
+        TEST_CASE_DIRECTORY="${FILE_TYPE,,}"
+
+        # We use configuration files to pass the list of files to lint to checkov
+        # Their name includes "checkov", which is equal to FILE_TYPE for Checkov.
+        # In this case, we don't add a trailing slash so we don't fail validation.
+        if [[ "${FILE_TYPE}" != "CHECKOV" ]]; then
+          TEST_CASE_DIRECTORY="${TEST_CASE_DIRECTORY}/"
+          debug "Adding a traling slash to the test case directory for ${FILE_TYPE}: ${TEST_CASE_DIRECTORY}"
+        fi
+
+        debug "TEST_CASE_DIRECTORY for ${FILE_TYPE}: ${TEST_CASE_DIRECTORY}"
+        if [[ ${FILE} != *"${TEST_CASE_DIRECTORY}"* ]]; then
+          debug "Excluding ${FILE} because it's not in the test case directory for ${FILE_TYPE}..."
+          continue
+        else
+          debug "Including ${FILE} because it's a test case for ${FILE_TYPE}"
+        fi
+      fi
+      FILE_ARRAY+=("${FILE}")
+    done <"${FILE_ARRAY_LANGUAGE_PATH}"
+  else
+    debug "${FILE_ARRAY_LANGUAGE_PATH} doesn't exist. Skip loading the list of files and directories to lint for ${FILE_TYPE}"
+  fi
+
+  if [[ "${#FILE_ARRAY[@]}" -eq 0 ]]; then
+    if [[ "${TEST_CASE_RUN}" == "false" ]]; then
+      debug "There are no items to lint for ${FILE_TYPE}"
+      unset -n FILE_ARRAY
+      return 0
+    else
+      fatal "Cannot find any tests for ${FILE_TYPE}"
+    fi
+  else
+    debug "There are ${#FILE_ARRAY[@]} items to lint for ${FILE_TYPE}: ${FILE_ARRAY[*]}"
+  fi
+
+  startGitHubActionsLogGroup "${FILE_TYPE}"
+
+  info "Linting ${FILE_TYPE} items..."
+
+  local PARALLEL_RESULTS_FILE_PATH
+  PARALLEL_RESULTS_FILE_PATH="/tmp/super-linter-worker-results-${FILE_TYPE}.json"
+  debug "PARALLEL_RESULTS_FILE_PATH for ${FILE_TYPE}: ${PARALLEL_RESULTS_FILE_PATH}"
+
+  local -a PARALLEL_COMMAND
+  PARALLEL_COMMAND=(parallel --will-cite --keep-order --max-procs "$(($(nproc) * 1))" --xargs --results "${PARALLEL_RESULTS_FILE_PATH}")
+
+  if [ "${LOG_DEBUG}" == "true" ]; then
+    debug "LOG_DEBUG is enabled. Enable verbose ouput for parallel"
+    PARALLEL_COMMAND+=(--verbose)
+  fi
+  debug "PARALLEL_COMMAND for ${FILE_TYPE}: ${PARALLEL_COMMAND[*]}"
+
+  # The following linters support linting one file at a time, and don't support linting a list of files,
+  # so we cannot pass more than one file per invocation
+  if [[ "${FILE_TYPE}" == "ANSIBLE" ]] ||
+    [[ "${FILE_TYPE}" == "ARM" ]] ||
+    [[ "${FILE_TYPE}" == "BASH_EXEC" ]] ||
+    [[ "${FILE_TYPE}" == "CLOJURE" ]] ||
+    [[ "${FILE_TYPE}" == "CSHARP" ]] ||
+    [[ "${FILE_TYPE}" == "GITLEAKS" ]] ||
+    [[ "${FILE_TYPE}" == "GO_MODULES" ]] ||
+    [[ "${FILE_TYPE}" == "JSCPD" ]] ||
+    [[ "${FILE_TYPE}" == "KOTLIN" ]] ||
+    [[ "${FILE_TYPE}" == "SQL" ]] ||
+    [[ "${FILE_TYPE}" == "SQLFLUFF" ]] ||
+    [[ "${FILE_TYPE}" == "CHECKOV" ]] ||
+    [[ "${FILE_TYPE}" == "POWERSHELL" ]] ||
+    [[ "${FILE_TYPE}" == "R" ]] ||
+    [[ "${FILE_TYPE}" == "RUST_CLIPPY" ]] ||
+    [[ "${FILE_TYPE}" == "SNAKEMAKE_LINT" ]] ||
+    [[ "${FILE_TYPE}" == "STATES" ]] ||
+    [[ "${FILE_TYPE}" == "TERRAFORM_TFLINT" ]] ||
+    [[ "${FILE_TYPE}" == "TERRAFORM_TERRASCAN" ]] ||
+    [[ "${FILE_TYPE}" == "TERRAGRUNT" ]]; then
+    debug "${FILE_TYPE} doesn't support linting files in batches. Configure the linter to run over the files to lint one by one"
+    PARALLEL_COMMAND+=(--max-lines 1)
+  fi
+  debug "PARALLEL_COMMAND for ${FILE_TYPE} after updating the number of files to lint per process: ${PARALLEL_COMMAND[*]}"
+
+  local LINTER_WORKING_DIRECTORY
+  LINTER_WORKING_DIRECTORY="${GITHUB_WORKSPACE}"
+
+  # GNU parallel parameter expansion:
+  # - {} input item
+  # - {/} basename of the input lint
+  # - {//} dirname of input line
+
+  if [[ ${FILE_TYPE} == "CSHARP" ]] ||
+    [[ (${FILE_TYPE} == "R" && -f "$(dirname "${FILE}")/.lintr") ]] ||
+    [[ ${FILE_TYPE} == "KOTLIN" ]] ||
+    [[ ${FILE_TYPE} == "TERRAFORM_TFLINT" ]]; then
+    LINTER_WORKING_DIRECTORY="{//}"
+  elif [[ ${FILE_TYPE} == "ANSIBLE" ]] ||
+    [[ ${FILE_TYPE} == "GO_MODULES" ]]; then
+    LINTER_WORKING_DIRECTORY="{}"
+  fi
+
+  debug "LINTER_WORKING_DIRECTORY for ${FILE_TYPE}: ${LINTER_WORKING_DIRECTORY}"
+  PARALLEL_COMMAND+=(--workdir "${LINTER_WORKING_DIRECTORY}")
+  debug "PARALLEL_COMMAND for ${FILE_TYPE} after updating the working directory: ${PARALLEL_COMMAND[*]}"
+
+  # shellcheck source=/dev/null
+  source /action/lib/functions/linterCommands.sh
+
+  local -n LINTER_COMMAND_ARRAY
+  LINTER_COMMAND_ARRAY="LINTER_COMMANDS_ARRAY_${FILE_TYPE}"
+  if [ ${#LINTER_COMMAND_ARRAY[@]} -eq 0 ]; then
+    fatal "LINTER_COMMAND_ARRAY for ${FILE_TYPE} is empty."
+  else
+    debug "LINTER_COMMAND_ARRAY for ${FILE_TYPE} has ${#LINTER_COMMAND_ARRAY[@]} elements: ${LINTER_COMMAND_ARRAY[*]}"
+  fi
+
+  PARALLEL_COMMAND+=("${LINTER_COMMAND_ARRAY[@]}")
+  debug "PARALLEL_COMMAND for ${FILE_TYPE} after LINTER_COMMAND_ARRAY concatenation: ${PARALLEL_COMMAND[*]}"
+
+  unset -n LINTER_COMMAND_ARRAY
+
+  local PARALLEL_COMMAND_OUTPUT
+  local PARALLEL_COMMAND_RETURN_CODE
+  PARALLEL_COMMAND_OUTPUT=$(printf "%s\n" "${FILE_ARRAY[@]}" | "${PARALLEL_COMMAND[@]}" 2>&1)
+  # Don't check for errors on this return code because commands can fail if linter report errors
+  PARALLEL_COMMAND_RETURN_CODE=$?
+  debug "PARALLEL_COMMAND_OUTPUT for ${FILE_TYPE} (exit code: ${PARALLEL_COMMAND_RETURN_CODE}): ${PARALLEL_COMMAND_OUTPUT}"
+  debug "Parallel output file (${PARALLEL_RESULTS_FILE_PATH}) contents for ${FILE_TYPE}:\n$(cat "${PARALLEL_RESULTS_FILE_PATH}")"
+
+  echo ${PARALLEL_COMMAND_RETURN_CODE} >"/tmp/super-linter-parallel-command-exit-code-${FILE_TYPE}"
+
+  if [ ${PARALLEL_COMMAND_RETURN_CODE} -ne 0 ]; then
+    error "Found errors when linting ${FILE_TYPE}. Exit code: ${PARALLEL_COMMAND_RETURN_CODE}."
+  else
+    notice "${FILE_TYPE} linted successfully"
+  fi
+
+  local RESULTS_OBJECT
+  RESULTS_OBJECT=
+  if ! RESULTS_OBJECT=$(jq -n '[inputs]' "${PARALLEL_RESULTS_FILE_PATH}"); then
+    fatal "Error loading results for ${FILE_TYPE}: ${RESULTS_OBJECT}"
+  fi
+  debug "RESULTS_OBJECT for ${FILE_TYPE}:\n${RESULTS_OBJECT}"
 
   # To count how many files were checked for a given FILE_TYPE
+  local INDEX
   INDEX=0
-
-  # To check how many "bad" and "good" test cases we ran
-  BAD_TEST_CASES_COUNT=0
-  GOOD_TEST_CASES_COUNT=0
-
-  WORKSPACE_PATH="${GITHUB_WORKSPACE}"
-  if [ "${TEST_CASE_RUN}" == "true" ]; then
-    WORKSPACE_PATH="${GITHUB_WORKSPACE}/${TEST_CASE_FOLDER}"
+  if ! ((INDEX = $(jq '[.[] | .V | length] | add' <<<"${RESULTS_OBJECT}"))); then
+    fatal "Error when setting INDEX for ${FILE_TYPE}: ${INDEX}"
   fi
-  debug "Workspace path: ${WORKSPACE_PATH}"
+  debug "Set INDEX for ${FILE_TYPE} to: ${INDEX}"
 
-  info ""
-  info "----------------------------------------------"
-  info "----------------------------------------------"
-  debug "Running LintCodebase. FILE_TYPE: ${FILE_TYPE}. Linter name: ${LINTER_NAME}, linter command: ${LINTER_COMMAND}, TEST_CASE_RUN: ${TEST_CASE_RUN}, FILTER_REGEX_INCLUDE: ${FILTER_REGEX_INCLUDE}, FILTER_REGEX_EXCLUDE: ${FILTER_REGEX_EXCLUDE}, files to lint: ${FILE_ARRAY[*]}"
-  info "Linting ${FILE_TYPE} files..."
-  info "----------------------------------------------"
-  info "----------------------------------------------"
-
-  for FILE in "${FILE_ARRAY[@]}"; do
-    info "Checking file: ${FILE}"
-
-    if [[ "${TEST_CASE_RUN}" == "true" ]]; then
-      # Folder for specific tests. By convention, the last part of the path is the lowercased FILE_TYPE
-      local TEST_CASE_DIRECTORY
-      TEST_CASE_DIRECTORY="${TEST_CASE_FOLDER}/${FILE_TYPE,,}/"
-      debug "TEST_CASE_DIRECTORY for ${FILE}: ${TEST_CASE_DIRECTORY}"
-
-      if [[ ${FILE} != *"${TEST_CASE_DIRECTORY}"* ]]; then
-        debug "Skipping ${FILE} because it's not in the test case directory for ${FILE_TYPE}..."
-        continue
-      fi
-    fi
-
-    local FILE_NAME
-    FILE_NAME=$(basename "${FILE}" 2>&1)
-    debug "FILE_NAME for ${FILE}: ${FILE_NAME}"
-
-    local DIR_NAME
-    DIR_NAME=$(dirname "${FILE}" 2>&1)
-    debug "DIR_NAME for ${FILE}: ${DIR_NAME}"
-
-    (("INDEX++"))
-
-    LINTED_LANGUAGES_ARRAY+=("${FILE_TYPE}")
-    local LINT_CMD
-    LINT_CMD=''
-
-    if [[ ${FILE_TYPE} == "POWERSHELL" ]] || [[ ${FILE_TYPE} == "ARM" ]]; then
-      # Need to run PowerShell commands using pwsh -c, also exit with exit code from inner subshell
-      LINT_CMD=$(
-        cd "${WORKSPACE_PATH}" || exit
-        pwsh -NoProfile -NoLogo -Command "${LINTER_COMMAND} \"${FILE}\"; if (\${Error}.Count) { exit 1 }"
-        exit $? 2>&1
-      )
-    elif [[ ${FILE_TYPE} == "R" ]]; then
-      local r_dir
-      if [ ! -f "${DIR_NAME}/.lintr" ]; then
-        r_dir="${WORKSPACE_PATH}"
-      else
-        r_dir="${DIR_NAME}"
-      fi
-      LINT_CMD=$(
-        cd "$r_dir" || exit
-        R --slave -e "lints <- lintr::lint('$FILE');print(lints);errors <- purrr::keep(lints, ~ .\$type == 'error');quit(save = 'no', status = if (length(errors) > 0) 1 else 0)" 2>&1
-      )
-    elif [[ ${FILE_TYPE} == "CSHARP" ]]; then
-      # Because the C# linter writes to tty and not stdout
-      LINT_CMD=$(
-        cd "${DIR_NAME}" || exit
-        ${LINTER_COMMAND} "${FILE_NAME}" | tee /dev/tty2 2>&1
-        exit "${PIPESTATUS[0]}"
-      )
-    elif [[ ${FILE_TYPE} == "ANSIBLE" ]] ||
-      [[ ${FILE_TYPE} == "GO_MODULES" ]]; then
-      debug "Linting ${FILE_TYPE}. Changing the working directory to ${FILE} before running the linter."
-      # Because it expects that the working directory is a Go module (GO_MODULES) or
-      # because we want to enable ansible-lint autodetection mode.
-      # Ref: https://ansible-lint.readthedocs.io/usage
-      LINT_CMD=$(
-        cd "${FILE}" || exit 1
-        ${LINTER_COMMAND} 2>&1
-      )
-    elif [[ ${FILE_TYPE} == "KOTLIN" ]]; then
-      # Because it needs to change directory to where the file to lint is
-      LINT_CMD=$(
-        cd "${DIR_NAME}" || exit
-        ${LINTER_COMMAND} "${FILE_NAME}" 2>&1
-      )
-    elif [[ ${FILE_TYPE} == "TERRAFORM_TFLINT" ]]; then
-      # Check the cache to see if we've already prepped this directory for tflint
-      if [[ ! -v "TFLINT_SEEN_DIRS[${DIR_NAME}]" ]]; then
-        debug "Configuring Terraform data directory for ${DIR_NAME}"
-
-        # Define the path to an empty Terraform data directory
-        # (def: https://developer.hashicorp.com/terraform/cli/config/environment-variables#tf_data_dir)
-        # in case the user has a Terraform data directory already, and we don't
-        # want to modify it.
-        # TFlint considers this variable as well.
-        # Ref: https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/compatibility.md#environment-variables
-        local TF_DATA_DIR
-        TF_DATA_DIR="/tmp/.terraform-${FILE_TYPE}-${DIR_NAME}"
-        export TF_DATA_DIR
-        # Let the cache know we've seen this before
-        # Set the value to an arbitrary non-empty string.
-
-        # Fetch Terraform modules
-        debug "Fetch Terraform modules for ${DIR_NAME} in ${TF_DATA_DIR}"
-        local FETCH_TERRAFORM_MODULES_CMD
-        FETCH_TERRAFORM_MODULES_CMD="$(terraform get)"
-        ERROR_CODE=$?
-        debug "Fetch Terraform modules. Exit code: ${ERROR_CODE}. Command output: ${FETCH_TERRAFORM_MODULES_CMD}"
-        if [ ${ERROR_CODE} -ne 0 ]; then
-          fatal "Error when fetching Terraform modules while linting ${FILE}"
-        fi
-        TFLINT_SEEN_DIRS[${DIR_NAME}]="false"
-      fi
-
-      # Because it needs to change the directory to where the file to lint is
-      LINT_CMD=$(
-        cd "${DIR_NAME}" || exit
-        ${LINTER_COMMAND} --filter="${FILE_NAME}" 2>&1
-      )
-    else
-      LINT_CMD=$(
-        cd "${WORKSPACE_PATH}" || exit
-        ${LINTER_COMMAND} "${FILE}" 2>&1
-      )
-    fi
-
-    ERROR_CODE=$?
-
-    local FILE_STATUS
-    # Assume that the file should pass linting checks
-    FILE_STATUS="good"
-
-    if [[ "${TEST_CASE_RUN}" == "true" ]] && [[ ${FILE} == *"bad"* ]]; then
-      FILE_STATUS="bad"
-      debug "We are running in test mode. Updating the expected FILE_STATUS for ${FILE} to: ${FILE_STATUS}"
-    fi
-
-    debug "Results for ${FILE}. Exit code: ${ERROR_CODE}. Command output:\n------\n${LINT_CMD}\n------"
-
-    ########################################
-    # File status = good, this should pass #
-    ########################################
-    if [[ ${FILE_STATUS} == "good" ]]; then
-      (("GOOD_TEST_CASES_COUNT++"))
-
-      if [ ${ERROR_CODE} -ne 0 ]; then
-        error "Found errors when linting ${FILE_NAME}. Exit code: ${ERROR_CODE}. Command output:\n------\n${LINT_CMD}\n------"
-        (("ERRORS_FOUND_${FILE_TYPE}++"))
-      else
-        notice "${FILE} was linted successfully"
-        if [ -n "${LINT_CMD}" ]; then
-          info "Command output for ${FILE_NAME}:\n------\n${LINT_CMD}\n------"
-        fi
-      fi
-    #######################################
-    # File status = bad, this should fail #
-    #######################################
-    else
-      if [[ "${TEST_CASE_RUN}" == "false" ]]; then
-        fatal "All files are supposed to pass linting checks when not running in test mode."
-      fi
-
-      (("BAD_TEST_CASES_COUNT++"))
-
-      if [ ${ERROR_CODE} -eq 0 ]; then
-        error "${FILE} should have failed test case."
-        (("ERRORS_FOUND_${FILE_TYPE}++"))
-      else
-        notice "${FILE} failed the test case as expected"
-      fi
-    fi
-  done
-
-  if [ "${TEST_CASE_RUN}" = "true" ]; then
-
-    debug "${LINTER_NAME} test suite has ${INDEX} test(s), of which ${BAD_TEST_CASES_COUNT} 'bad' (expected to fail), ${GOOD_TEST_CASES_COUNT} 'good' (expected to pass)."
-
-    # Check if we ran at least one test
-    if [ "${INDEX}" -eq 0 ]; then
-      fatal "Failed to find any tests ran for: ${LINTER_NAME}. Check that tests exist for linter: ${LINTER_NAME}"
-    fi
-
-    # Check if we ran at least one 'bad' test
-    if [ "${BAD_TEST_CASES_COUNT}" -eq 0 ]; then
-      fatal "Failed to find any tests that are expected to fail for: ${LINTER_NAME}. Check that tests that are expected to fail exist for linter: ${LINTER_NAME}"
-    fi
-
-    # Check if we ran at least one 'good' test
-    if [ "${GOOD_TEST_CASES_COUNT}" -eq 0 ]; then
-      fatal "Failed to find any tests that are expected to pass for: ${LINTER_NAME}. Check that tests that are expected to pass exist for linter: ${LINTER_NAME}"
-    fi
+  local STDOUT_LINTER
+  # Get raw output so we can strip quotes from the data we load
+  if ! STDOUT_LINTER="$(jq --raw-output '.[].Stdout' <<<"${RESULTS_OBJECT}")"; then
+    fatal "Error when loading stdout for ${FILE_TYPE}:\n${STDOUT_LINTER}"
   fi
+
+  if [ -n "${STDOUT_LINTER}" ]; then
+    info "Command output for ${FILE_TYPE}:\n------\n${STDOUT_LINTER}\n------"
+  else
+    debug "Stdout for ${FILE_TYPE} is empty"
+  fi
+
+  local STDERR_LINTER
+  if ! STDERR_LINTER="$(jq --raw-output '.[].Stderr' <<<"${RESULTS_OBJECT}")"; then
+    fatal "Error when loading stderr for ${FILE_TYPE}:\n${STDERR_LINTER}"
+  fi
+
+  if [ -n "${STDERR_LINTER}" ]; then
+    info "Command output for ${FILE_TYPE}:\n------\n${STDERR_LINTER}\n------"
+  else
+    debug "Stderr for ${FILE_TYPE} is empty"
+  fi
+
+  unset -n FILE_ARRAY
+
+  endGitHubActionsLogGroup "${FILE_TYPE}"
 }
+
+# We need this for parallel
+export -f LintCodebase

--- a/test/inspec/super-linter/controls/super_linter.rb
+++ b/test/inspec/super-linter/controls/super_linter.rb
@@ -436,6 +436,7 @@ control "super-linter-validate-files" do
     "/action/lib/functions/buildFileList.sh",
     "/action/lib/functions/detectFiles.sh",
     "/action/lib/functions/githubEvent.sh",
+    "/action/lib/functions/linterCommands.sh",
     "/action/lib/functions/linterRules.sh",
     "/action/lib/functions/linterVersions.sh",
     "/action/lib/functions/linterVersions.txt",

--- a/test/run-super-linter-tests.sh
+++ b/test/run-super-linter-tests.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SUPER_LINTER_TEST_CONTAINER_URL="${1}"
+TEST_FUNCTION_NAME="${2}"
+
+COMMAND_TO_RUN=(docker run -e ACTIONS_RUNNER_DEBUG=true -e DEFAULT_BRANCH=main -e ENABLE_GITHUB_ACTIONS_GROUP_TITLE=true -e JSCPD_CONFIG_FILE=".jscpd-test-linters.json" -e RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES="default.json,hoge.json" -e RUN_LOCAL=true -e TEST_CASE_RUN=true -e TYPESCRIPT_STANDARD_TSCONFIG_FILE=".github/linters/tsconfig.json" -v "$(pwd):/tmp/lint")
+
+run_test_cases_expect_failure() {
+  COMMAND_TO_RUN+=(-e ANSIBLE_DIRECTORY="/test/linters/ansible/bad" -e CHECKOV_FILE_NAME=".checkov-test-linters-failure.yaml" -e FILTER_REGEX_INCLUDE=".*bad.*")
+  EXPECTED_EXIT_CODE=1
+}
+
+run_test_cases_expect_success() {
+  COMMAND_TO_RUN+=(-e ANSIBLE_DIRECTORY="/test/linters/ansible/good" -e CHECKOV_FILE_NAME=".checkov-test-linters-success.yaml" -e FILTER_REGEX_INCLUDE=".*good.*")
+}
+
+# Run the test setup function
+${TEST_FUNCTION_NAME}
+
+COMMAND_TO_RUN+=("${SUPER_LINTER_TEST_CONTAINER_URL}")
+
+declare -i EXPECTED_EXIT_CODE
+EXPECTED_EXIT_CODE=${EXPECTED_EXIT_CODE:-0}
+
+if [ ${EXPECTED_EXIT_CODE} -ne 0 ]; then
+  echo "Disable failures on error because the expected exit code is ${EXPECTED_EXIT_CODE}"
+  set +o errexit
+fi
+
+echo "Command to run: ${COMMAND_TO_RUN[*]}"
+
+"${COMMAND_TO_RUN[@]}"
+SUPER_LINTER_EXIT_CODE=$?
+# Enable the errexit option in case we disabled it
+set -o errexit
+
+echo "Super-linter exit code: ${SUPER_LINTER_EXIT_CODE}"
+
+if [ ${SUPER_LINTER_EXIT_CODE} -ne ${EXPECTED_EXIT_CODE} ]; then
+  echo "Super-linter exited with an unexpected code: ${SUPER_LINTER_EXIT_CODE}"
+  exit 1
+else
+  echo "Super-linter exited with the expected code: ${SUPER_LINTER_EXIT_CODE}"
+fi


### PR DESCRIPTION
# Proposed changes

- Parallelize building the file list
- Parallelize linters
- Enable Gitleaks to run against single files because it's parallelized, so there's no reason to treat it in a special way.

Fix #5073

The tasks I parallelized are, by far, the most expensive tasks. We could also parallelize the configuration of linter config files, but that takes a few seconds only.

To implement these changes, I had to refactor things a bit:

- Don't use a `.gitleaksignore` because Gitleaks doesn't provide a way to ignore this file. This was causing issues when running tests.
- Don't handle special cases to exclude `bad` and `good` tests. Use `FILTER_REGEX_EXCLUDE` and `FILTER_REGEX_INCLUDE` instead.
- Fix an issue with Checkov not linting files if the configuration file included the list of directories to lint.
- Move the logic to run linter tests to a script to reduce duplication in the `Makefile`, and to enable further error checks. I'll reduce duplication even more in a follow up PR.
- Remove the `WORKSPACE_PATH` variable. Use `GITHUB_WORKSPACE` only to reduce the things to consider.
- Use temporary files to hold the list of files to lint, and return codes so that processes can read them. This is necessary to implement a robust inter-process communication. Environment variables are too fragile for this purpose.
- Move linter commands to a dedicated file that processes can source as needed because Bash doesn't currently offer a reliable way to export arrays.
- Save output in JSON files and parse them to print it as needed.
- Export some functions and variables so that subprocesses can use them.
- Move the logic to run "additional installations" to the `RunAdditionalInstalls` function instead of having them scattered around several places.
- Use arrays to store commands instead of an associative array of strings to properly handle escapes and arguments.
- To differentiate between different test cases, we now return: `0` if everything was linted fine, `1` if there were errors, `2` if there were errors, but some linters reported success.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
