### PR TITLE
feat: don't check bake files with terragrunt

### DIFF
--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -569,7 +569,11 @@ function BuildFileList() {
     ############################
     # Get the Terragrunt files #
     ############################
-    elif [ "${FILE_TYPE}" == "hcl" ] && [[ ${FILE} != *".tflint.hcl"* ]] && [[ ${FILE} != *".pkr.hcl"* ]]; then
+    elif [ "${FILE_TYPE}" == "hcl" ] &&
+      [[ ${FILE} != *".tflint.hcl"* ]] &&
+      [[ ${FILE} != *".pkr.hcl"* ]] &&
+      [[ ${FILE} != *"docker-bake.hcl"* ]] &&
+      [[ ${FILE} != *"docker-bake.override.hcl"* ]]; then
       FILE_ARRAY_TERRAGRUNT+=("${FILE}")
 
     ############################


### PR DESCRIPTION
# Proposed changes

Exclude the default docker bake files in HCL format from the list of files to lint with Terragrunt.

Note that Docker bake supports defining arbitrary names for configuration files, so this commit doesn't cover the scenario that a user defined an arbitrary name for a Docker bake configuration file in HCL format. Example: example-bake-config-file.hcl will be included in the list of files to lint with Terragrunt.

Ref (default bake names):
https://docs.docker.com/build/bake/reference/#file-format

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
