### PR TITLE
Ignore changelog when linting codebase

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -2,16 +2,16 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "changelog-sections": [
     {
-      "section": "⬆️ Dependency updates",
-      "type": "deps"
-    },
-    {
       "section": "🚀 Features",
       "type": "feat"
     },
     {
-      "section": "🐛 Bug fixes",
+      "section": "🐛 Bugfixes",
       "type": "fix"
+    },
+    {
+      "section": "⬆️ Dependency updates",
+      "type": "deps"
     },
     {
       "section": "🧰 Maintenance",

--- a/.textlintignore
+++ b/.textlintignore
@@ -1,6 +1,0 @@
-CHANGELOG.md
-test/linters/jscpd/good/markdown_good_1.md
-test/linters/markdown/markdown_bad_1.md
-test/linters/markdown/markdown_bad_1.md
-test/linters/markdown/markdown_good_1.md
-test/linters/natural_language/bad/natural_language_bad_01.md

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ test-git-flags: ## Run super-linter with different git-related flags
 		-e ACTIONS_RUNNER_DEBUG=true \
 		-e ERROR_ON_MISSING_EXEC_BIT=true \
 		-e ENABLE_GITHUB_ACTIONS_GROUP_TITLE=true \
-		-e FILTER_REGEX_EXCLUDE=".*/test/linters/.*" \
+		-e FILTER_REGEX_EXCLUDE=".*(/test/linters/|CHANGELOG.md).*" \
 		-e DEFAULT_BRANCH=main \
 		-e IGNORE_GENERATED_FILES=true \
 		-e IGNORE_GITIGNORED_FILES=true \
@@ -179,7 +179,7 @@ lint-codebase: ## Lint the entire codebase
 		-e ACTIONS_RUNNER_DEBUG=true \
 		-e DEFAULT_BRANCH=main \
 		-e ENABLE_GITHUB_ACTIONS_GROUP_TITLE=true \
-		-e FILTER_REGEX_EXCLUDE=".*/test/linters/.*" \
+		-e FILTER_REGEX_EXCLUDE=".*(/test/linters/|CHANGELOG.md).*" \
 		-e GITLEAKS_CONFIG_FILE=".gitleaks-ignore-tests.toml" \
 		-e RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES="default.json,hoge.json" \
 		-e VALIDATE_ALL_CODEBASE=true \
@@ -198,7 +198,7 @@ lint-subset-files-enable-only-one-type: ## Lint a small subset of files in the c
 		-e ACTIONS_RUNNER_DEBUG=true \
 		-e DEFAULT_BRANCH=main \
 		-e ENABLE_GITHUB_ACTIONS_GROUP_TITLE=true \
-		-e FILTER_REGEX_EXCLUDE=".*/test/linters/.*" \
+		-e FILTER_REGEX_EXCLUDE=".*(/test/linters/|CHANGELOG.md).*" \
 		-e VALIDATE_ALL_CODEBASE=true \
 		-e VALIDATE_MARKDOWN=true \
 		-v "$(CURDIR):/tmp/lint" \
@@ -211,7 +211,7 @@ lint-subset-files-enable-expensive-io-checks: ## Lint a small subset of files in
 		-e ACTIONS_RUNNER_DEBUG=true \
 		-e DEFAULT_BRANCH=main \
 		-e ENABLE_GITHUB_ACTIONS_GROUP_TITLE=true \
-		-e FILTER_REGEX_EXCLUDE=".*/test/linters/.*" \
+		-e FILTER_REGEX_EXCLUDE=".*(/test/linters/|CHANGELOG.md).*" \
 		-e VALIDATE_ALL_CODEBASE=true \
 		-e VALIDATE_ARM=true \
 		-e VALIDATE_CLOUDFORMATION=true \


### PR DESCRIPTION
# Proposed changes

CHANGELOG.md is automatically generated by the release workflow. Ignore it when linting the codebase because it might not pass textlint validation because of lowercase terms.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
