### PR TITLE
Fail on errors when installing chktex

### DIFF
--- a/scripts/install-chktex.sh
+++ b/scripts/install-chktex.sh
@@ -11,12 +11,13 @@ apk add --no-cache --virtual .chktex-build-deps \
   libtool \
   make
 
-git clone https://git.savannah.gnu.org/git/chktex.git &&
-  cd chktex/chktex &&
-  ./autogen.sh --prefix=/usr/bin &&
-  ./configure &&
-  make &&
-  install chktex /usr/bin
+git clone https://git.savannah.gnu.org/git/chktex.git
+
+cd chktex/chktex
+./autogen.sh --prefix=/usr/bin
+./configure
+make
+install chktex /usr/bin
 
 rm -rfv /chktex
 


### PR DESCRIPTION
# Proposed changes

Refactor the chktex installation scripts because lists of commands don't fail if one of them exits with an error, even if set -e (errexit) is set.

See the Bash reference manual, section 4.3.1 'The Set Builtin'.

Fix #5122

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
