### PR TITLE
Initialize terrascan at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -391,11 +391,6 @@ ENV PATH="${PATH}:${DART_SDK}/bin:/root/.pub-cache/bin"
 ENV VERSION_FILE="/action/linterVersions.txt"
 RUN mkdir /action
 
-# Initialize Terrascan
-# Initialize ChkTeX config file
-RUN terrascan init --log-level "debug" \
-    && touch ~/.chktexrc
-
 ENTRYPOINT ["/action/lib/linter.sh"]
 
 FROM base_image as slim

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 all: info docker test ## Run all targets.
 
 .PHONY: test
-test: info validate-container-image-labels test-lib inspec lint-codebase test-default-config-files test-find lint-subset-files test-custom-ssl-cert test-non-default-workdir test-git-flags test-log-level test-linters ## Run the test suite
+test: info validate-container-image-labels test-lib inspec lint-codebase test-default-config-files test-find lint-subset-files test-custom-ssl-cert test-non-default-workdir test-git-flags test-non-default-home-directory test-log-level test-linters ## Run the test suite
 
 # if this session isn't interactive, then we don't want to allocate a
 # TTY, which would fail, but if it is interactive, we do want to attach
@@ -288,6 +288,12 @@ test-custom-ssl-cert: ## Test the configuration of a custom SSL/TLS certificate
 		-e SSL_CERT_SECRET="$(shell cat test/data/ssl-certificate/rootCA-test.crt)" \
 		-v "$(CURDIR)/docs":/tmp/lint \
 		$(SUPER_LINTER_TEST_CONTAINER_URL)
+
+.phony: test-non-default-home-directory
+test-non-default-home-directory: ## Test a non-default HOME directory
+	$(CURDIR)/test/run-super-linter-tests.sh \
+		$(SUPER_LINTER_TEST_CONTAINER_URL) \
+		"run_test_cases_non_default_home"
 
 .phony: test-linters
 test-linters: test-linters-expect-success test-linters-expect-failure ## Run the linters test suite

--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -156,7 +156,7 @@ function BuildFileList() {
   if ! RESULTS_OBJECT=$(jq --raw-output -n '[inputs]' "${PARALLEL_RESULTS_FILE_PATH}"); then
     fatal "Error loading results when building the file list: ${RESULTS_OBJECT}"
   fi
-  debug "RESULTS_OBJECT for ${FILE_TYPE}:\n${RESULTS_OBJECT}"
+  debug "RESULTS_OBJECT when building the file list:\n${RESULTS_OBJECT}"
 
   local STDOUT_BUILD_FILE_LIST
   # Get raw output so we can strip quotes from the data we load

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -444,6 +444,22 @@ function RunAdditionalInstalls() {
     done
   fi
 
+  if [ "${VALIDATE_TERRAFORM_TERRASCAN}" == "true" ] && [ -e "${FILE_ARRAYS_DIRECTORY_PATH}/file-array-TERRAFORM_TERRASCAN" ]; then
+    info "Initializing Terrascan repository"
+    local -a TERRASCAN_INIT_COMMAND
+    TERRASCAN_INIT_COMMAND=(terrascan init -c "${TERRAFORM_TERRASCAN_LINTER_RULES}")
+    if [[ "${LOG_DEBUG}" == "true" ]]; then
+      TERRASCAN_INIT_COMMAND+=(--log-level "debug")
+    fi
+    debug "Terrascan init command: ${TERRASCAN_INIT_COMMAND[*]}"
+
+    local TERRASCAN_INIT_COMMAND_OUTPUT
+    if ! TERRASCAN_INIT_COMMAND_OUTPUT="$("${TERRASCAN_INIT_COMMAND[@]}" 2>&1)"; then
+      fatal "Error while initializing Terrascan:\n${TERRASCAN_INIT_COMMAND_OUTPUT}"
+    fi
+    debug "Terrascan init command output:\n${TERRASCAN_INIT_COMMAND_OUTPUT}"
+  fi
+
   # Check if there's local configuration for the Raku linter
   if [ -e "${GITHUB_WORKSPACE}/META6.json" ]; then
     cd "${GITHUB_WORKSPACE}" && zef install --deps-only --/test .

--- a/test/inspec/super-linter/controls/super_linter.rb
+++ b/test/inspec/super-linter/controls/super_linter.rb
@@ -495,8 +495,7 @@ control "super-linter-validate-files" do
     "/action/lib/.automation/.yaml-lint.yml",
     "/action/lib/.automation/phpcs.xml",
     "/action/lib/.automation/phpstan.neon",
-    "/action/lib/.automation/psalm.xml",
-    "/root/.chktexrc"
+    "/action/lib/.automation/psalm.xml"
   ]
 
   files.each do |item|

--- a/test/linters/terraform_terrascan/good/terraform-terrascan_good_2.tf
+++ b/test/linters/terraform_terrascan/good/terraform-terrascan_good_2.tf
@@ -1,0 +1,15 @@
+resource "aws_instance" "instanceWithVpc2" {
+  ami           = "some-id"
+  instance_type = "t2.micro"
+  monitoring = true
+  ebs_optimized = true
+
+  vpc_security_group_ids = ["sg-12345678901234567"]
+  subnet_id = "subnet-12345678901234567"
+  metadata_options {
+    http_endpoint = "disabled"
+  }
+  tags = {
+    Name = "HelloWorld"
+  }
+}

--- a/test/run-super-linter-tests.sh
+++ b/test/run-super-linter-tests.sh
@@ -23,6 +23,11 @@ run_test_cases_log_level() {
   LOG_LEVEL="NOTICE"
 }
 
+run_test_cases_non_default_home() {
+  run_test_cases_expect_success
+  COMMAND_TO_RUN+=(-e HOME=/tmp)
+}
+
 # Run the test setup function
 ${TEST_FUNCTION_NAME}
 


### PR DESCRIPTION
# Proposed changes

Terrascan runs initialization anyway when scanning files, so there's no point in running it at build time. Also, this works around a Terrascan bug that caused it to fail its initialization if $HOME/.terrascan directory is not present. This happens on GitHub Actions because it configures a $HOME directory that is different from ours.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
