### PR TITLE
Show error output when info is disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 all: info docker test ## Run all targets.
 
 .PHONY: test
-test: info validate-container-image-labels test-lib inspec lint-codebase test-default-config-files test-find lint-subset-files test-custom-ssl-cert test-non-default-workdir test-git-flags test-non-default-home-directory test-log-level test-linters ## Run the test suite
+test: info validate-container-image-labels test-lib inspec lint-codebase test-default-config-files test-find lint-subset-files test-custom-ssl-cert test-non-default-workdir test-git-flags test-non-default-home-directory test-log-level test-linters-expect-failure-log-level-notice test-linters ## Run the test suite
 
 # if this session isn't interactive, then we don't want to allocate a
 # TTY, which would fail, but if it is interactive, we do want to attach
@@ -315,6 +315,12 @@ test-log-level: ## Run a test to check if there are conflicts with the LOG_LEVEL
 	$(CURDIR)/test/run-super-linter-tests.sh \
 		$(SUPER_LINTER_TEST_CONTAINER_URL) \
 		"run_test_cases_log_level"
+
+.phony: test-linters-expect-failure-log-level-notice
+test-linters-expect-failure-log-level-notice: ## Run the linters test suite expecting failures with a LOG_LEVEL set to NOTICE
+	$(CURDIR)/test/run-super-linter-tests.sh \
+		$(SUPER_LINTER_TEST_CONTAINER_URL) \
+		"run_test_cases_expect_failure_notice_log"
 
 .phony: build-dev-container-image
 build-dev-container-image: ## Build commit linter container image

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -318,7 +318,7 @@ function RunAdditionalInstalls() {
     local MYPY_CACHE_DIRECTORY_PATH
     MYPY_CACHE_DIRECTORY_PATH="${GITHUB_WORKSPACE}/.mypy_cache"
     debug "Create MyPy cache directory: ${MYPY_CACHE_DIRECTORY_PATH}"
-    mkdir -v "${MYPY_CACHE_DIRECTORY_PATH}"
+    mkdir -p "${MYPY_CACHE_DIRECTORY_PATH}"
   fi
 
   ###############################

--- a/lib/functions/worker.sh
+++ b/lib/functions/worker.sh
@@ -193,7 +193,16 @@ function LintCodebase() {
   fi
 
   if [ -n "${STDOUT_LINTER}" ]; then
-    info "Command output for ${FILE_TYPE}:\n------\n${STDOUT_LINTER}\n------"
+    local STDOUT_LINTER_LOG_MESSAGE
+    STDOUT_LINTER_LOG_MESSAGE="Command output for ${FILE_TYPE}:\n------\n${STDOUT_LINTER}\n------"
+    info "${STDOUT_LINTER_LOG_MESSAGE}"
+
+    if [ ${PARALLEL_COMMAND_RETURN_CODE} -ne 0 ]; then
+      local STDOUT_LINTER_FILE_PATH
+      STDOUT_LINTER_FILE_PATH="/tmp/super-linter-parallel-stdout-${FILE_TYPE}"
+      debug "Saving stdout for ${FILE_TYPE} to ${STDOUT_LINTER_FILE_PATH} in case we need it later"
+      printf '%s\n' "${STDOUT_LINTER_LOG_MESSAGE}" >"${STDOUT_LINTER_FILE_PATH}"
+    fi
   else
     debug "Stdout for ${FILE_TYPE} is empty"
   fi
@@ -204,7 +213,15 @@ function LintCodebase() {
   fi
 
   if [ -n "${STDERR_LINTER}" ]; then
-    info "Stderr contents for ${FILE_TYPE}:\n------\n${STDERR_LINTER}\n------"
+    local STDERR_LINTER_LOG_MESSAGE
+    STDERR_LINTER_LOG_MESSAGE="Stderr contents for ${FILE_TYPE}:\n------\n${STDERR_LINTER}\n------"
+    info "${STDERR_LINTER_LOG_MESSAGE}"
+    if [ ${PARALLEL_COMMAND_RETURN_CODE} -ne 0 ]; then
+      local STDERR_LINTER_FILE_PATH
+      STDERR_LINTER_FILE_PATH="/tmp/super-linter-parallel-stderr-${FILE_TYPE}"
+      debug "Saving stderr for ${FILE_TYPE} to ${STDERR_LINTER_FILE_PATH} in case we need it later"
+      printf '%s\n' "${STDERR_LINTER_LOG_MESSAGE}" >"${STDERR_LINTER_FILE_PATH}"
+    fi
   else
     debug "Stderr for ${FILE_TYPE} is empty"
   fi

--- a/test/run-super-linter-tests.sh
+++ b/test/run-super-linter-tests.sh
@@ -23,6 +23,11 @@ run_test_cases_log_level() {
   LOG_LEVEL="NOTICE"
 }
 
+run_test_cases_expect_failure_notice_log() {
+  run_test_cases_expect_failure
+  LOG_LEVEL="NOTICE"
+}
+
 run_test_cases_non_default_home() {
   run_test_cases_expect_success
   COMMAND_TO_RUN+=(-e HOME=/tmp)


### PR DESCRIPTION
# Proposed changes

In case of linting errors, print stdout and stderr (if present) at the ERROR level if users set LOG_LEVEL to NOTICE to avoid failures without any explanation.

Close #5218

Worth waiting for #5249 before merging this one, so we can benefit from the test script enhancements implemented in that PR.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
