### PR TITLE
Take package-lock into account in dev-container

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 100
 
   - package-ecosystem: github-actions
     commit-message:
@@ -16,6 +17,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 100
 
   - package-ecosystem: "npm"
     commit-message:
@@ -23,6 +25,7 @@ updates:
     directory: "/dependencies"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 100
 
   - package-ecosystem: "bundler"
     commit-message:
@@ -30,6 +33,7 @@ updates:
     directory: "/dependencies"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 100
 
   - package-ecosystem: "docker"
     commit-message:
@@ -37,6 +41,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 100
 
   - package-ecosystem: "pip"
     commit-message:
@@ -44,6 +49,7 @@ updates:
     directory: "/dependencies/python/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 100
 
   - package-ecosystem: "gradle"
     commit-message:
@@ -51,6 +57,7 @@ updates:
     directory: "/dependencies/checkstyle"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 100
 
   - package-ecosystem: "gradle"
     commit-message:
@@ -58,6 +65,7 @@ updates:
     directory: "/dependencies/google-java-format"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 100
 
   - package-ecosystem: "gradle"
     commit-message:
@@ -65,6 +73,7 @@ updates:
     directory: "/dependencies/ktlint"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 100
 
   - package-ecosystem: "docker"
     commit-message:
@@ -72,6 +81,7 @@ updates:
     directory: "/dev-dependencies"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 100
 
   - package-ecosystem: "npm"
     commit-message:
@@ -79,3 +89,4 @@ updates:
     directory: "/dev-dependencies"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 100

--- a/dev-dependencies/Dockerfile
+++ b/dev-dependencies/Dockerfile
@@ -7,16 +7,16 @@ RUN apt-get update \
   jq \
   && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
+ENV APP_DIR=/app
+WORKDIR "${APP_DIR}"
 
-COPY package.json ./
+COPY package.json package-lock.json ./
 
-ENV NPM_PACKAGES_FILE_PATH="npm-packages.txt"
+RUN npm ci \
+  && rm -rf ~/.npm
 
-RUN jq '.dependencies | to_entries[] | select(.key | startswith("@commitlint/")) | .key + "@" + .value' package.json >> "${NPM_PACKAGES_FILE_PATH}" \
-  && jq '.dependencies | to_entries[] | select(.key | startswith("release-please")) | .key + "@" + .value' package.json >> "${NPM_PACKAGES_FILE_PATH}" \
-  && xargs npm install -g < "${NPM_PACKAGES_FILE_PATH}" \
-  && rm package.json "${NPM_PACKAGES_FILE_PATH}"
+ENV NODE_PATH="${APP_DIR}/node_modules"
+ENV PATH="${NODE_PATH}/.bin:${PATH}"
 
 # Split this from the previous RUN instruction so we can cache the costly installation step
 # hadolint ignore=DL3059


### PR DESCRIPTION
# Proposed changes

Consider package-lock.json when building the dev-container so we can enforce a known-working dependency chain. This caused issues in the past when commitlint and release-please had bugs in new versions  that impacted our build pipeline.

I also took the chance to revert a change to dependabot config that sneaked in a past PR.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
