### PR TITLE
Configure git user and email when pushing a new release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -253,6 +253,9 @@ jobs:
       - name: Tag major, minor, and latest versions
         if: steps.release.outputs.release_created
         run: |
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
           git tag --annotate --force ${{ env.SEMVER_MAJOR_VERSION }} -m "Release ${{ env.SEMVER_MAJOR_VERSION }}"
           git tag --annotate --force latest -m "Release latest (${{ env.RELEASE_VERSION }})"
 


### PR DESCRIPTION
# Proposed changes

Set Git user and email in the CD workflow to correctly push new tags.

Fix #5283

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
