### PR TITLE
Don't explicitly install typescript eslint parser

### DIFF
--- a/dependencies/package-lock.json
+++ b/dependencies/package-lock.json
@@ -14,7 +14,6 @@
         "@react-native/eslint-config": "^0.73.2",
         "@stoplight/spectral-cli": "^6.11.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
-        "@typescript-eslint/parser": "^6.20.0",
         "asl-validator": "^3.8.2",
         "eslint": "^8.56.0",
         "eslint-config-airbnb": "^19.0.4",
@@ -6980,6 +6979,7 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.20.0.tgz",
       "integrity": "sha512-bYerPDF/H5v6V76MdMYhjwmwgMA+jlPVqjSDq2cRqMi8bP5sR3Z+RLOiOMad3nsnmDVmn2gAFCyNgh/dIrfP/w==",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.20.0",
         "@typescript-eslint/types": "6.20.0",
@@ -7007,6 +7007,7 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.20.0.tgz",
       "integrity": "sha512-p4rvHQRDTI1tGGMDFQm+GtxP1ZHyAh64WANVoyEcNMpaTFn3ox/3CcgtIlELnRfKzSs/DwYlDccJEtr3O6qBvA==",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "6.20.0",
         "@typescript-eslint/visitor-keys": "6.20.0"
@@ -7023,6 +7024,7 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.20.0.tgz",
       "integrity": "sha512-MM9mfZMAhiN4cOEcUOEx+0HmuaW3WBfukBZPCfwSqFnQy0grXYtngKCqpQN339X3RrwtzspWJrpbrupKYUSBXQ==",
+      "peer": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
       },
@@ -7035,6 +7037,7 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.20.0.tgz",
       "integrity": "sha512-RnRya9q5m6YYSpBN7IzKu9FmLcYtErkDkc8/dKv81I9QiLLtVBHrjz+Ev/crAqgMNW2FCsoZF4g2QUylMnJz+g==",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "6.20.0",
         "@typescript-eslint/visitor-keys": "6.20.0",
@@ -7062,6 +7065,7 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.20.0.tgz",
       "integrity": "sha512-E8Cp98kRe4gKHjJD4NExXKz/zOJ1A2hhZc+IMVD6i7w4yjIvh6VyuRI0gRtxAsXtoC35uGMaQ9rjI2zJaXDEAw==",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "6.20.0",
         "eslint-visitor-keys": "^3.4.1"
@@ -7078,6 +7082,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -7086,6 +7091,7 @@
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
       "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },

--- a/dependencies/package.json
+++ b/dependencies/package.json
@@ -9,7 +9,6 @@
     "@react-native/eslint-config": "^0.73.2",
     "@stoplight/spectral-cli": "^6.11.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
-    "@typescript-eslint/parser": "^6.20.0",
     "asl-validator": "^3.8.2",
     "eslint": "^8.56.0",
     "eslint-config-airbnb": "^19.0.4",


### PR DESCRIPTION
# Proposed changes

`@typescript-eslint/parser` is a transitory dependency, don't explicitly install it so it doesn't conflict with other requirements.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
