### PR TITLE
Suggest setting fetch-depth on ref errors

### DIFF
--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -8,6 +8,7 @@ function IssueHintForFullGitHistory() {
   info "See https://github.com/super-linter/super-linter#get-started"
   info "Is shallow repository: $(git -C "${GITHUB_WORKSPACE}" rev-parse --is-shallow-repository)"
 }
+export -f IssueHintForFullGitHistory
 
 function GenerateFileDiff() {
   local DIFF_GIT_DEFAULT_BRANCH_CMD

--- a/lib/functions/validation.sh
+++ b/lib/functions/validation.sh
@@ -200,6 +200,7 @@ function ValidateGitShaReference() {
 
   debug "Validate that the GITHUB_SHA reference (${GITHUB_SHA}) exists in this Git repository."
   if ! CheckIfGitRefExists "${GITHUB_SHA}"; then
+    IssueHintForFullGitHistory
     fatal "The GITHUB_SHA reference (${GITHUB_SHA}) doesn't exist in this Git repository"
   else
     debug "The GITHUB_SHA reference (${GITHUB_SHA}) exists in this repository"


### PR DESCRIPTION
# Proposed changes

Emit a hopefully more helpful error message when the Git ref doesn't exist. The error message is the same we use when getting changed files only: it suggests checking that repository clone is not shallow, and that the full history is available. Additionally, when running on GitHub Actions, it also suggests checking the fetch-depth option of the actions/checkout step.

Fix #5315

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
