### PR TITLE
Install zlib from alpine packages

### DIFF
--- a/scripts/install-glibc.sh
+++ b/scripts/install-glibc.sh
@@ -2,19 +2,6 @@
 
 set -euo pipefail
 
-case $TARGETARCH in
-amd64)
-  target=x86_64
-  ;;
-arm64)
-  target=arm64
-  ;;
-*)
-  echo "$TARGETARCH is not supported"
-  exit 1
-  ;;
-esac
-
 url=$(
   set -euo pipefail
   curl -s \
@@ -31,14 +18,9 @@ apk add --no-cache --force-overwrite "glibc-${GLIBC_VERSION}.apk"
 rm "glibc-${GLIBC_VERSION}.apk"
 
 # Install zlib
-mkdir /tmp/libz
-
 apk add --no-cache --virtual .glibc-build-deps \
   tar \
+  zlib \
   zstd
-
-curl --retry 5 --retry-delay 5 -sL https://www.archlinux.org/packages/core/${target}/zlib/download | tar -x --zstd -C /tmp/libz
-mv /tmp/libz/usr/lib/libz.so* /usr/glibc-compat/lib
-rm -rf /tmp/libz
 
 apk del --no-network --purge .glibc-build-deps


### PR DESCRIPTION
# Proposed changes

Running `install-glibc.sh` failed in ARM64, because arch linux packages doesn't offer a build for `arm64`. i.e. `https://www.archlinux.org/packages/core/arm64/zlib/download` returns a 404.

Related to #5070

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
