### PR TITLE
Don't immediately exit on errors

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -24,6 +24,10 @@
     {
       "section": "🧰 Maintenance",
       "type": "ci"
+    },
+    {
+      "section": "🧰 Maintenance",
+      "type": "docs"
     }
   ],
   "packages": {

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -o errexit
 set -o nounset
 set -o pipefail
 
@@ -658,6 +657,7 @@ UpdateLoopsForImage() {
 # shellcheck disable=SC2317
 cleanup() {
   local -ri EXIT_CODE=$?
+  debug "Captured exit code: ${EXIT_CODE}"
 
   if [ -n "${GITHUB_WORKSPACE:-}" ]; then
     debug "Removing temporary files and directories"

--- a/scripts/linterVersions.sh
+++ b/scripts/linterVersions.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -o errexit
 set -o nounset
 set -o pipefail
 


### PR DESCRIPTION
# Proposed changes

- Don't immediately exit on errors because this will hide diagnostic information, and linter output.
- Add documentation updates PRs to the changelog.

Fix #5335

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
