### PR TITLE
Remove cpanm cache to fix uid issue when using rootless container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -202,6 +202,7 @@ RUN apk add --no-cache --virtual .perl-build-deps \
     Perl::Critic::StricterSubs \
     Perl::Critic::Swift \
     Perl::Critic::Tics \
+    && rm -rf /root/.cpanm \
     && apk del --no-network --purge .perl-build-deps
 
 #################


### PR DESCRIPTION
This is similar to #3785 except in this case the high uid is for a file that does not need to be in the `super-linter` image as it is just build cache.

Pulling v6.3.0 is failing when using docker with user uid remapping:
```
failed to register layer: Container ID 197609 cannot be mapped to a host ID
```

Trying to pull with rootless podman show a more useful:

```
Error: copying system image from manifest list: writing blob: adding layer with blob "sha256:98088679e87a1114d3dafa114c911c1d8e5d33fffe624cfdd43b589a136a5f0f": ApplyLayer stdout:  stderr: potentially insufficient UIDs or GIDs available in user namespace (requested 197609:197609 for /root/.cpanm/work/1708379740.11/PPI-1.277): Check /etc/subuid and /etc/subgid if configured locally and run podman-system-migrate: lchown /root/.cpanm/work/1708379740.11/PPI-1.277: invalid argument exit status 1
```

# Proposed changes

Remove the cpanm work dir.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [ ] Label as `breaking` if this change breaks compatibility with the previous released version.
- [ ] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
