### PR TITLE
Set permissions in the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ To run super-linter as a GitHub Action, you do the following:
       push: null
       pull_request: null
 
+    permissions: { }
+
     jobs:
       build:
         name: Lint


### PR DESCRIPTION
adding:
permissions: read-all

This is to avoid failure of super-linter that is triggered by `checkov`.

`checkov` flags that the top-level permissions are set to "write-all" (default value). Accordingly, the action will fail with an error.

# Proposed changes

Small addition to the yaml example as described above

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [ ] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [ ] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [ ] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [ ] Label as `breaking` if this change breaks compatibility with the previous released version.
- [ ] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.