### PR TITLE
Do not print the whole environment

### DIFF
--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -788,15 +788,6 @@ BuildFileList "${VALIDATE_ALL_CODEBASE}" "${TEST_CASE_RUN}"
 #####################################
 RunAdditionalInstalls
 
-####################################
-# Print ENV before running linters #
-####################################
-debug "--- ENV (before running linters) ---"
-debug "------------------------------------"
-debug "ENV:"
-debug "$(printenv)"
-debug "------------------------------------"
-
 endGitHubActionsLogGroup "${SUPER_LINTER_INITIALIZATION_LOG_GROUP_TITLE}"
 
 ###############


### PR DESCRIPTION
# Proposed changes

Printing the whole environment clutters the log too much. Also, it might expose sensitive information in the unlikely event that GitHub Actions don't identify certain output as secrets.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
