### PR TITLE
ci: do not run by pull request from fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   preview-release-notes:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name == 'super-linter/super-linter'
     runs-on: ubuntu-latest
     permissions:
         contents: read


### PR DESCRIPTION
# Proposed changes

https://github.com/super-linter/super-linter/actions/runs/8676845957/job/23791768591?pr=5505

```
ConfigurationError: base (super-linter/super-linter): Missing required manifest versions: .github/release-please/.release-please-manifest.json
    at fetchReleasedVersions (/app/node_modules/release-please/build/src/manifest.js:915:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async parseReleasedVersions (/app/node_modules/release-please/build/src/manifest.js:894:26)
    at async Promise.all (index 1)
    at async Manifest.fromManifest (/app/node_modules/release-please/build/src/manifest.js:121:93)
    at async Object.handler (/app/node_modules/release-please/build/src/bin/release-please.js:319:24) {
  releaserName: 'base',
  repository: 'super-linter/super-linter'
}
make: *** [Makefile:397: release-please-dry-run] Error 1
```

CI `preview-release-notes` will not run properly if this CI is not run by pull request from fork.
Therefore, I will fix it that this CI is not run by pull request from fork.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
