### PR TITLE
ci: fix a run condition in CI preview-release-notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   preview-release-notes:
-    if: github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name == 'super-linter/super-linter'
+    if: github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name && github.repository == 'super-linter/super-linter'
     runs-on: ubuntu-latest
     permissions:
         contents: read


### PR DESCRIPTION
# Proposed changes

CI `preview-release-notes` do not run when PR is submitted directly.
This is probably because three or more conditions can not be connected equally in GitHub Actions' `if` statement.
Therefore, I split these.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [ ] Label as `breaking` if this change breaks compatibility with the previous released version.
- [ ] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
