### PR TITLE
ci: ignore github_conf in jscpd

### DIFF
--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -36,6 +36,7 @@
     "**/test/linters/scalafmt",
     "**/test/linters/tekton/**",
     "**/test/linters/typescript_es/**",
+    "**/github_conf/**",
     "**/workflows/cd.yml"
   ],
   "reporters": [


### PR DESCRIPTION
# Proposed changes

https://github.com/super-linter/super-linter/actions/runs/8674328025/job/23786540069

```
  2024-04-13 15:06:04 [INFO]   Linting JSCPD items...
  2024-04-13 15:06:05 [ERROR]   Found errors when linting JSCPD. Exit code: 1.
  2024-04-13 15:06:05 [INFO]   Command output for JSCPD:
  ------
  Error: ENOENT: no such file or directory, open '/github/workspace/github_conf/branch_protection_rules.json'
      at Object.openSync (node:fs:581:18)
      at Object.readFileSync (node:fs:457:35)
      at addContentToEntry (/node_modules/@jscpd/finder/dist/files.js:68:32)
      at Array.map (<anonymous>)
      at Object.getFilesToDetect (/node_modules/@jscpd/finder/dist/files.js:94:10)
      at exports.detectClones (/node_modules/jscpd/dist/index.js:27:28)
      at Object.<anonymous> (/node_modules/jscpd/dist/index.js:70:28)
      at Generator.next (<anonymous>)
      at /node_modules/jscpd/dist/index.js:8:71
      at new Promise (<anonymous>) {
    errno: -2,
    code: 'ENOENT',
    syscall: 'open',
    path: '/github/workspace/github_conf/branch_protection_rules.json'
  }
```

checkov creates a `github_conf` directory at runtime (See `CKV_GITHUB_CONF_DIR_NAME` Section in https://www.checkov.io/7.Scan%20Examples/Github.html ).
An error occurs if jscpd reads this.
Therefore, I ignore this from the running target of jscpd.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [ ] Label as `breaking` if this change breaks compatibility with the previous released version.
- [ ] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
