### PR TITLE
Respect log level and color support when writing to the log

### DIFF
--- a/lib/functions/log.sh
+++ b/lib/functions/log.sh
@@ -75,7 +75,7 @@ LOG_TEMP=$(mktemp) || echo "Failed to create temporary log file."
 export LOG_TEMP
 
 log() {
-  local PRINT_TO_STDOUT="${1}"
+  local EMIT_LOG_MESSAGE="${1}"
   local MESSAGE="${2}"
   local LOG_LEVEL_LABEL="${3}"
 
@@ -107,12 +107,17 @@ log() {
   local MESSAGE_FOR_LOG_FILE
   MESSAGE_FOR_LOG_FILE="${LOG_MESSAGE_DATE} ${LOG_LEVEL_LABEL}   ${MESSAGE}"
 
-  if [[ "${PRINT_TO_STDOUT}" == "true" ]]; then
-    echo -e "${COLORED_MESSAGE}"
-  fi
+  if [[ "${EMIT_LOG_MESSAGE}" == "true" ]]; then
+    # Emit colors only if there's a terminal
+    if [ -t 0 ]; then
+      echo -e "${COLORED_MESSAGE}"
+    else
+      echo -e "${MESSAGE_FOR_LOG_FILE}"
+    fi
 
-  if [ "${CREATE_LOG_FILE}" = "true" ]; then
-    echo -e "${MESSAGE_FOR_LOG_FILE}" >>"${LOG_TEMP}"
+    if [ "${CREATE_LOG_FILE}" = "true" ]; then
+      echo -e "${MESSAGE_FOR_LOG_FILE}" >>"${LOG_TEMP}"
+    fi
   fi
 }
 


### PR DESCRIPTION
# Proposed changes

- Write log messages in the log file according to the LOG_LEVEL that the user configured (or the default), instead of printing all the messages regardless of LOG_LEVEL to the log file.
- Don't emit colors if there is no terminal

Close #5337

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
