### PR TITLE
Configure ruff with a temp cache

### DIFF
--- a/TEMPLATES/.ruff.toml
+++ b/TEMPLATES/.ruff.toml
@@ -1,3 +1,6 @@
+# Store the cache in a temporary location
+cache-dir = "/tmp/.ruff_cache"
+
 # Same as .flake8
 line-length = 120
 

--- a/test/run-super-linter-tests.sh
+++ b/test/run-super-linter-tests.sh
@@ -109,3 +109,21 @@ if [ ${SUPER_LINTER_EXIT_CODE} -ne ${EXPECTED_EXIT_CODE} ]; then
 else
   echo "Super-linter exited with the expected code: ${SUPER_LINTER_EXIT_CODE}"
 fi
+
+# Check if super-linter leaves leftovers behind
+declare -a TEMP_ITEMS_TO_CLEAN
+TEMP_ITEMS_TO_CLEAN=()
+TEMP_ITEMS_TO_CLEAN+=("$(pwd)/.lintr")
+TEMP_ITEMS_TO_CLEAN+=("$(pwd)/.mypy_cache")
+TEMP_ITEMS_TO_CLEAN+=("$(pwd)/.ruff_cache")
+TEMP_ITEMS_TO_CLEAN+=("$(pwd)/logback.log")
+
+for item in "${TEMP_ITEMS_TO_CLEAN[@]}"; do
+  echo "Check if ${item} exists"
+  if [[ -e "${item}" ]]; then
+    echo "Error: ${item} exists and it should have been deleted"
+    exit 1
+  else
+    echo "${item} does not exist as expected"
+  fi
+done


### PR DESCRIPTION
# Proposed changes

- Configure Ruff to store its cache in a temporary directory inside the container by default. Users can still override this by providing a configuration file for Ruff.
- Add tests to ensure that super-linter deletes temporary files and directories.

Close #5543

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
