### PR TITLE
No full Git validation when ignoring files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 all: info docker test ## Run all targets.
 
 .PHONY: test
-test: info validate-container-image-labels test-lib inspec lint-codebase test-default-config-files test-actions-runner-debug test-actions-steps-debug test-runner-debug test-find lint-subset-files test-custom-ssl-cert test-non-default-workdir test-git-flags test-non-default-home-directory test-git-initial-commit test-log-level test-linters-expect-failure-log-level-notice test-bash-exec-library-expect-success test-bash-exec-library-expect-failure test-linters ## Run the test suite
+test: info validate-container-image-labels test-lib inspec lint-codebase test-default-config-files test-actions-runner-debug test-actions-steps-debug test-runner-debug test-find lint-subset-files test-custom-ssl-cert test-non-default-workdir test-git-flags test-non-default-home-directory test-git-initial-commit test-log-level test-use-find-and-ignore-gitignored-files test-linters-expect-failure-log-level-notice test-bash-exec-library-expect-success test-bash-exec-library-expect-failure test-linters ## Run the test suite
 
 # if this session isn't interactive, then we don't want to allocate a
 # TTY, which would fail, but if it is interactive, we do want to attach
@@ -378,6 +378,12 @@ test-git-initial-commit: ## Run super-linter against a repository that only has 
 	$(CURDIR)/test/run-super-linter-tests.sh \
 		$(SUPER_LINTER_TEST_CONTAINER_URL) \
 		"run_test_case_git_initial_commit"
+
+.PHONY: test-use-find-and-ignore-gitignored-files
+test-use-find-and-ignore-gitignored-files: ## Run super-linter with USE_FIND_ALGORITHM=true and IGNORE_GITIGNORED_FILES=true
+	$(CURDIR)/test/run-super-linter-tests.sh \
+		$(SUPER_LINTER_TEST_CONTAINER_URL) \
+		"run_test_case_use_find_and_ignore_gitignored_files"
 
 .PHONY: build-dev-container-image
 build-dev-container-image: ## Build commit linter container image

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -760,8 +760,14 @@ GetValidationInfo
 if [[ "${USE_FIND_ALGORITHM}" == "false" ]] || [[ "${IGNORE_GITIGNORED_FILES}" == "true" ]]; then
   debug "Validate the local Git environment"
   ValidateLocalGitRepository
-  ValidateGitShaReference
-  ValidateDefaultGitBranch
+
+  # We need to validate the commit SHA reference and the default branch only when
+  # using Git to get the list of files to lint
+  if [[ "${USE_FIND_ALGORITHM}" == "false" ]]; then
+    debug "Validate the Git SHA and branch references"
+    ValidateGitShaReference
+    ValidateDefaultGitBranch
+  fi
 else
   debug "Skipped the validation of the local Git environment because we don't depend on it."
 fi

--- a/test/run-super-linter-tests.sh
+++ b/test/run-super-linter-tests.sh
@@ -11,6 +11,10 @@ DEFAULT_BRANCH="main"
 
 COMMAND_TO_RUN=(docker run -t -e DEFAULT_BRANCH="${DEFAULT_BRANCH}" -e ENABLE_GITHUB_ACTIONS_GROUP_TITLE=true)
 
+ignore_test_cases() {
+  COMMAND_TO_RUN+=(-e FILTER_REGEX_EXCLUDE=".*(/test/linters/|CHANGELOG.md).*")
+}
+
 configure_linters_for_test_cases() {
   COMMAND_TO_RUN+=(-e TEST_CASE_RUN=true -e JSCPD_CONFIG_FILE=".jscpd-test-linters.json" -e RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES="default.json,hoge.json" -e TYPESCRIPT_STANDARD_TSCONFIG_FILE=".github/linters/tsconfig.json")
 }
@@ -77,6 +81,12 @@ run_test_case_git_initial_commit() {
   COMMAND_TO_RUN+=(-e MULTI_STATUS=false)
   COMMAND_TO_RUN+=(-e VALIDATE_ALL_CODEBASE=false)
   COMMAND_TO_RUN+=(-e VALIDATE_JSON=true)
+}
+
+run_test_case_use_find_and_ignore_gitignored_files() {
+  ignore_test_cases
+  COMMAND_TO_RUN+=(-e IGNORE_GITIGNORED_FILES=true)
+  COMMAND_TO_RUN+=(-e USE_FIND_ALGORITHM=true)
 }
 
 # Run the test setup function


### PR DESCRIPTION
# Proposed changes

- Don't require Git SHA and branch validation when IGNORE_GITIGNORED_FILES=true because we only need to validate that the workspace is a Git repository in this case.

Fix #5383

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
