### PR TITLE
Remove deployment configuration from ci

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,6 @@ jobs:
       cancel-in-progress: true
     permissions:
       contents: read
-      deployments: write
       issues: write
       packages: write
     strategy:
@@ -106,14 +105,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Start deployment
-        uses: bobheadxi/deployments@v1.5.0
-        id: deployment
-        with:
-          step: start
-          token: ${{ secrets.GITHUB_TOKEN }}
-          env: Production
-
       - name: Build and Push Image
         uses: docker/build-push-action@v5
         with:
@@ -132,21 +123,6 @@ jobs:
           tags: |
             ${{ env.CONTAINER_IMAGE_ID }}
           target: "${{ matrix.images.target }}"
-
-      - name: Update deployment
-        uses: bobheadxi/deployments@v1.5.0
-        # We depend on the 'deployment' step outputs, so we can't run this step
-        # if the 'deployment' step didn't run. This can happen if any step
-        # before the 'deployment' step fails. That's why 'always()' is not
-        # suitable here.
-        if: steps.deployment.conclusion != 'cancelled' && steps.deployment.conclusion != 'skipped'
-        with:
-          step: finish
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}
-          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env: ${{ steps.deployment.outputs.env }}
-          env_url: https://github.com/super-linter/super-linter
 
       - name: Create Issue on Failure
         uses: actions/github-script@v7
@@ -174,7 +150,6 @@ jobs:
       cancel-in-progress: true
     permissions:
       contents: write
-      deployments: write
       issues: write
       packages: write
       pull-requests: write
@@ -186,15 +161,6 @@ jobs:
           config-file: .github/release-please/release-please-config.json
           manifest-file: .github/release-please/.release-please-manifest.json
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Start deployment
-        if: steps.release.outputs.release_created
-        uses: bobheadxi/deployments@v1.5.0
-        id: deployment
-        with:
-          step: start
-          token: ${{ secrets.GITHUB_TOKEN }}
-          env: Release
 
       - name: Configure release metedata
         if: steps.release.outputs.release_created
@@ -263,21 +229,6 @@ jobs:
 
           git push --force origin ${{ env.SEMVER_MAJOR_VERSION }}
           git push --force origin latest
-
-      - name: Update deployment
-        uses: bobheadxi/deployments@v1.5.0
-        # We depend on the 'deployment' step outputs, so we can't run this step
-        # if the 'deployment' step didn't run. This can happen if any step
-        # before the 'deployment' step fails. That's why 'always()' is not
-        # suitable here.
-        if: steps.deployment.conclusion != 'cancelled' && steps.deployment.conclusion != 'skipped'
-        with:
-          step: finish
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}
-          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env: ${{ steps.deployment.outputs.env }}
-          env_url: https://github.com/super-linter/super-linter
 
       - name: Create Issue on Failure
         uses: actions/github-script@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     permissions:
-        contents: read
+      contents: read
     concurrency:
       # Ref: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
       # github.head_ref: head_ref or source branch of the pull request


### PR DESCRIPTION
# Proposed changes

Simplify the CI workflows by skipping GitHub deployments configuration. We don't use deployments in any other place at the moment.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
