### PR TITLE
Move local action test to a dedicated job

### DIFF
--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -37,7 +37,8 @@
     "**/test/linters/tekton/**",
     "**/test/linters/typescript_es/**",
     "**/github_conf/**",
-    "**/workflows/cd.yml"
+    "**/workflows/cd.yml",
+    "**/workflows/ci.yml"
   ],
   "reporters": [
     "consoleFull"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 permissions: {}
 
 jobs:
-  test:
+  build-container-image:
     name: Build and Test
     runs-on: ubuntu-latest
     permissions:
@@ -39,13 +39,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Update action.yml
-        run: |
-          echo "yq version: $(yq --version)"
-          yq '.runs.image = env(CONTAINER_IMAGE_ID)' -i action.yml
-          echo "Action file contents:"
-          cat action.yml
 
       - name: Set build metadata
         run: |
@@ -112,6 +105,60 @@ jobs:
         run: |
           docker load <"/tmp/${{ env.CONTAINER_IMAGE_OUTPUT_IMAGE_NAME }}.tar"
 
+      # Validate the container image labels here so we don't have to pass the expected
+      # label values to other build jobs
+      - name: Validate container image labels
+        run: make validate-container-image-labels
+
+      - name: Upload ${{ env.CONTAINER_IMAGE_OUTPUT_IMAGE_NAME }} container image
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: ${{ env.CONTAINER_IMAGE_OUTPUT_IMAGE_NAME }}
+          path: /tmp/${{ env.CONTAINER_IMAGE_OUTPUT_IMAGE_NAME }}.tar
+
+  test-local-action:
+    name: Test the Super-linter GitHub Action
+    runs-on: ubuntu-latest
+    needs: build-container-image
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        images:
+          - container-image-id: super-linter-latest
+            prefix: ""
+            target: standard
+          - container-image-id: super-linter-slim-latest
+            prefix: slim-
+            target: slim
+    env:
+      CONTAINER_IMAGE_ID: "ghcr.io/super-linter/super-linter:${{ matrix.images.prefix }}latest"
+      CONTAINER_IMAGE_TARGET: "${{ matrix.images.target }}"
+      CONTAINER_IMAGE_OUTPUT_IMAGE_NAME: "super-linter-${{ matrix.images.prefix }}latest"
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download ${{ env.CONTAINER_IMAGE_OUTPUT_IMAGE_NAME }} container image
+        uses: actions/download-artifact@v4.1.7
+        with:
+          name: ${{ env.CONTAINER_IMAGE_OUTPUT_IMAGE_NAME }}
+          path: /tmp
+
+      - name: Load ${{ env.CONTAINER_IMAGE_OUTPUT_IMAGE_NAME }} container image
+        run: |
+          docker load --input /tmp/${{ env.CONTAINER_IMAGE_OUTPUT_IMAGE_NAME }}.tar
+          docker image ls -a
+
+      - name: Update action.yml
+        run: |
+          echo "yq version: $(yq --version)"
+          yq '.runs.image = env(CONTAINER_IMAGE_ID)' -i action.yml
+          echo "Action file contents:"
+          cat action.yml
+
       - name: Test Local Action (debug log)
         uses: ./
         env:
@@ -138,21 +185,9 @@ jobs:
           FILTER_REGEX_EXCLUDE: ".*(/test/linters/|CHANGELOG.md).*"
           TYPESCRIPT_STANDARD_TSCONFIG_FILE: ".github/linters/tsconfig.json"
 
-      # Validate the container image labels here so we don't have to pass the expected
-      # label values to other build jobs
-      - name: Validate container image labels
-        run: make validate-container-image-labels
-
-      - name: Upload ${{ env.CONTAINER_IMAGE_OUTPUT_IMAGE_NAME }} container image
-        uses: actions/upload-artifact@v4.3.3
-        with:
-          name: ${{ env.CONTAINER_IMAGE_OUTPUT_IMAGE_NAME }}
-          path: /tmp/${{ env.CONTAINER_IMAGE_OUTPUT_IMAGE_NAME }}.tar
-
   build-test-suite-matrix:
     name: Build test suite matrix
     runs-on: ubuntu-latest
-    needs: test
     permissions:
       contents: read
     outputs:
@@ -174,7 +209,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: build-test-suite-matrix
+    needs:
+      - build-container-image
+      - build-test-suite-matrix
     strategy:
       matrix:
         test-case: ${{ fromJson(needs.build-test-suite-matrix.outputs.matrix) }}
@@ -220,7 +257,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name && github.repository == 'super-linter/super-linter'
     runs-on: ubuntu-latest
     permissions:
-        contents: read
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
# Proposed changes

Move local action test to a dedicated job.

This is another step towards reducing duplication in our workflows.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
