### PR TITLE
chore: reduce container image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -376,8 +376,35 @@ COPY --from=clj-kondo /bin/clj-kondo /usr/bin/
 # Install dart-sdk #
 ####################
 ENV DART_SDK=/usr/lib/dart
-COPY --from=dart "${DART_SDK}" "${DART_SDK}"
-RUN chmod 755 "${DART_SDK}" && chmod 755 "${DART_SDK}/bin"
+# These COPY directives may be compacted after --parents is supported
+COPY --from=dart --chmod=0755 \
+  "${DART_SDK}/version" \
+  "${DART_SDK}"/
+COPY --from=dart --chmod=0755 \
+  "${DART_SDK}/bin/dart" \
+  "${DART_SDK}/bin/dart.sym" \
+  "${DART_SDK}/bin"/
+COPY --from=dart --chmod=0755 \
+  "${DART_SDK}/bin/snapshots/analysis_server.dart.snapshot" \
+  "${DART_SDK}/bin/snapshots/dartdev.dart.snapshot" \
+  "${DART_SDK}/bin/snapshots/frontend_server_aot.dart.snapshot" \
+  "${DART_SDK}/bin/snapshots"/
+COPY --from=dart --chmod=0755 \
+  "${DART_SDK}/lib/_internal" \
+  "${DART_SDK}/lib/_internal"
+COPY --from=dart --chmod=0755 \
+  "${DART_SDK}/lib/async" \
+  "${DART_SDK}/lib/async"
+COPY --from=dart --chmod=0755 \
+  "${DART_SDK}/lib/convert" \
+  "${DART_SDK}/lib/convert"
+COPY --from=dart --chmod=0755 \
+  "${DART_SDK}/lib/core" \
+  "${DART_SDK}/lib/core"
+COPY --from=dart --chmod=0755 \
+  "${DART_SDK}/lib/io" \
+  "${DART_SDK}/lib/io"
+
 
 ########################
 # Install clang-format #


### PR DESCRIPTION
# Proposed changes

The baseline container image size for the `standard` flavor is:
- 6.04GB (v6.4.1)
- 5.94GB (v7.0.0)
- 5.87GB (v7.3.0)
- 5.89GB (097074244fb53480adb40ecd7586abda3c2246bf)

Reduce container image size, starting from 097074244fb53480adb40ecd7586abda3c2246bf:

- Remove unneeded Dart SDK components.
- Add `--production` flag to `npm install`

Size down to 5.51GB

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
