### PR TITLE
Install lua from the os package repository

### DIFF
--- a/scripts/install-lua.sh
+++ b/scripts/install-lua.sh
@@ -2,39 +2,21 @@
 
 set -euo pipefail
 
+apk add --no-cache \
+  lua5.4
+
 apk add --no-cache --virtual .lua-build-deps \
   gcc \
+  lua5.4-dev \
+  luarocks5.4 \
   make \
   musl-dev \
   readline-dev
 
-curl --retry 5 --retry-delay 5 -s https://www.lua.org/ftp/lua-5.3.5.tar.gz | tar -xz
-cd lua-5.3.5
-make linux
-make install
-cd .. && rm -r lua-5.3.5/
+ln -s /usr/bin/lua5.4 /usr/bin/lua
 
-url=$(
-  set -euo pipefail
-  curl -s \
-    -H "Accept: application/vnd.github+json" \
-    -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
-    https://api.github.com/repos/cvega/luarocks/releases/latest |
-    jq -r '.tarball_url'
-)
-curl --retry 5 --retry-delay 5 -sL \
-  -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
-  "${url}" | tar -xz
-cd cvega-luarocks-6b1aee6
-./configure --with-lua-include=/usr/local/include
-make
-make -b install
-cd ..
-rm -r cvega-luarocks-6b1aee6
-
-luarocks install luacheck
-luarocks install argparse
-luarocks install luafilesystem
+luarocks-5.4 install luacheck
+luarocks-5.4 install argparse
+luarocks-5.4 install luafilesystem
 
 apk del --no-network --purge .lua-build-deps


### PR DESCRIPTION
# Proposed changes

- Install lua and luarocks from the OS package repository instead of manually downloading them. Also the luarock fork looked unmaintained.
- Remove luarocks from the image after installing lua packages because it's not needed after that

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
