### PR TITLE
docs: update issue form to include version info

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,8 +13,34 @@ body:
       label: Is there an existing issue for this?
       description: Search to see if an issue already exists for the bug you encountered.
       options:
-      - label: I have searched the existing issues
-        required: true
+        - label: I have searched the existing issues
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Are you using the latest Super-linter version available?
+      description: |
+        Ensure that you're using the latest Super-linter version.
+        https://github.com/super-linter/super-linter/releases/latest
+      options:
+        - label: I am using the latest Super-linter version.
+          required: true
+        - label: |
+            I can reproduce the issue running Super-linter using complete version identifier (example: vX.Y.Z), and not just with a partial one (example: vX)
+          required: true
+        - label: |
+            I am using the super-linter/super-linter action or container image, and not the deprecated github/super-linter action or container image.
+          required: true
+  - type: checkboxes
+    attributes:
+      label: Are you resonably sure that it's a Super-linter issue, and not an issue related to a tool that Super-linter runs?
+      description: |
+        If you encounter a specific issue, ensure that the issue is about
+        Super-linter, and not about a tool that Super-linter runs. For example,
+        if a linter reports an unexpected or a surprising error, you may check
+        if there are similar issues reported in that linter's issue tracker.
+      options:
+        - label: I think that this is a Super-linter issue.
+          required: true
   - type: textarea
     attributes:
       label: Current Behavior
@@ -45,6 +71,7 @@ body:
         Copy and paste any relevant log output.
         This will be automatically formatted into code, so no need for backticks.
         Enable debug logging, either on GitHub Actions, or when running locally.
+        Not attaching debug logging will delay the issue triaging process.
       render: shell
     validations:
       required: true
@@ -67,7 +94,5 @@ body:
       label: Anything else?
       description: |
         Links? References? Anything that will give us more context about the issue you are encountering!
-
-        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -34,9 +34,7 @@ body:
     attributes:
       label: Anything else?
       description: |
-        Links? References? Anything that will give us more context about the issue you are encountering!
-
-        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+        Links? References? Anything that will give us more context about the issue you are encountering.
     validations:
       required: false
 

--- a/.github/pull_request-template.md
+++ b/.github/pull_request-template.md
@@ -8,15 +8,17 @@ In order to have this pull request merged, complete the following tasks.
 
 ### Pull request author tasks
 
+- [ ] I checked that all workflows return a success.
 - [ ] I included all the needed documentation for this change.
 - [ ] I provided the necessary tests.
 - [ ] I squashed all the commits into a single commit.
 - [ ] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
 - [ ] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
 - [ ] If this pull request is about and existing issue,
-  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.
+  I added the `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of the pull request.
 
 ### Super-linter maintainer tasks
 
 - [ ] Label as `breaking` if this change breaks compatibility with the previous released version.
 - [ ] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
+- [ ] Add the pull request to a milestone, eventually creating one, that matches with the version that release-please proposes.


### PR DESCRIPTION
# Proposed changes

Given the amount of issues due to using outdated versions:

- Require users to reproduce issues with the latest Super-linter version.
- Remind users to use super-linter/super-linter, and not the deprecated github/super-linter.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
