### PR TITLE
Run a job on test suite success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Update action.yml
         run: |
           echo "yq version: $(yq --version)"
-          yq '.runs.image = env(CONTAINER_IMAGE_ID)' -i action.yml
+          yq '.runs.image = "docker://" + env(CONTAINER_IMAGE_ID)' -i action.yml
           echo "Action file contents:"
           cat action.yml
 
@@ -252,6 +252,25 @@ jobs:
           make ${{ matrix.test-case }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # The purpose of this job is to run only when the run-test-suite job runs to completion.
+  # We can use this job as a required status check in a branch protection rule without
+  # having to select each individual job that dynamically add to the test matrix.
+  test-success-placeholder:
+    name: Check if all the tests passed
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs:
+      - run-test-suite
+      - test-local-action
+    steps:
+      - name: Test suite success
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Test suite failures
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
 
   preview-release-notes:
     if: github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name && github.repository == 'super-linter/super-linter'

--- a/test/linters/github_actions/actions_good_01.yml
+++ b/test/linters/github_actions/actions_good_01.yml
@@ -8,7 +8,6 @@ jobs:
   github_actions_good:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - if: ${{ github.actor == 'dependabot[bot]' }}
         run: |
           # CMD


### PR DESCRIPTION
# Proposed changes

- Run a job after all the jobs in the dynamically built test matrix run to completion. This job is useful for branch protection rules that that need the whole test suite to run successfully.
- Fix linting issues.

Fix #5686

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` label to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
