### PR TITLE
deps(php): update php linters

### DIFF
--- a/dependencies/phive.xml
+++ b/dependencies/phive.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
   <!-- When adding new linter, do not forget to add its GPG key ID to Dockerfile -->
-  <phar name="composer" version="^2.6.6" installed="2.6.6" location="./usr/bin/composer" copy="false"/>
-  <phar name="phpcs" version="^3.8.0" installed="3.8.0" location="/usr/local/bin/phpcs" copy="true"/>
-  <phar name="phpstan" version="^1.10.48" installed="1.10.48" location="/usr/local/bin/phpstan" copy="true"/>
-  <phar name="psalm" version="^5.17.0" installed="4.18.1" location="./usr/local/bin/psalm" copy="true"/>
+  <phar name="composer" version="^2.7.6" installed="2.7.6" location="./usr/bin/composer" copy="false"/>
+  <phar name="phpcs" version="^3.10.1" installed="3.10.1" location="/usr/local/bin/phpcs" copy="true"/>
+  <phar name="phpstan" version="^1.11.2" installed="1.11.2" location="/usr/local/bin/phpstan" copy="true"/>
+  <phar name="psalm" version="^5.24.0" installed="5.24.0" location="./usr/local/bin/psalm" copy="true"/>
 </phive>

--- a/scripts/install-phive.sh
+++ b/scripts/install-phive.sh
@@ -8,7 +8,7 @@ apk add --no-cache --virtual .php-build-deps \
 # Install phive
 curl --retry 5 --retry-delay 5 -sLO https://phar.io/releases/phive.phar
 curl --retry 5 --retry-delay 5 -sLO https://phar.io/releases/phive.phar.asc
-gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "0x9D8A98B29B2D5D79"
+gpg --keyserver hkps://keys.openpgp.org --recv-keys "0x9D8A98B29B2D5D79"
 gpg --verify phive.phar.asc phive.phar
 chmod +x phive.phar
 mv phive.phar /usr/local/bin/phive
@@ -16,7 +16,7 @@ rm phive.phar.asc
 
 # Install the PHARs listed in phive.xml
 phive --no-progress install \
-  --trust-gpg-keys 31C7E470E2138192,CF1A108D0E7AE720,8A03EA3B385DBAA1,12CE0F1D262429A5,5E6DDE998AB73B8E,51C67305FFC2E5C0,CBB3D576F2A0946F \
+  --trust-gpg-keys 31C7E470E2138192,CF1A108D0E7AE720,8A03EA3B385DBAA1,12CE0F1D262429A5,5E6DDE998AB73B8E,51C67305FFC2E5C0,CBB3D576F2A0946F,689DAD778FF08760E046228BA978220305CD5C32 \
   --target /usr/bin
 
 apk del --no-network --purge .php-build-deps


### PR DESCRIPTION
# Proposed changes

- Composer to 2.7.6
- PHPCS to 3.10.1
- PHPStan to 1.11.2
- Psalm to 5.24.0

This also fixes the build because of outdated keys.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches with the version that release-please proposes.
