### PR TITLE
fix: don't skip processing ansible_directory pwd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,14 @@ docker: check-github-token ## Build the container image
 docker-pull: ## Pull the container image from registry
 	docker pull $(SUPER_LINTER_TEST_CONTAINER_URL)
 
+.PHONY: open-shell-super-linter-container
+open-shell-super-linter-container: ## Open a shell in the Super-linter container
+	docker run $(DOCKER_FLAGS) \
+		--interactive \
+		--entrypoint /bin/bash \
+		-v "$(CURDIR)":/tmp/lint \
+		$(SUPER_LINTER_TEST_CONTAINER_URL)
+
 .PHONY: validate-container-image-labels
 validate-container-image-labels: ## Validate container image labels
 	$(CURDIR)/test/validate-docker-labels.sh \

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -269,7 +269,7 @@ function IsGenerated() {
   fi
 }
 
-# We need these functions when building the file list with paralle
+# We need these functions when building the file list with parallel
 export -f CheckFileType
 export -f DetectActions
 export -f DetectARMFile
@@ -421,3 +421,18 @@ function RunAdditionalInstalls() {
     cd "${GITHUB_WORKSPACE}" && zef install --deps-only --/test .
   fi
 }
+
+function IsAnsibleDirectory() {
+  local FILE
+  FILE="$1"
+
+  debug "Checking if ${FILE} is the Ansible directory (${ANSIBLE_DIRECTORY})"
+  if [[ ("${FILE}" =~ .*${ANSIBLE_DIRECTORY}.*) ]] && [[ -d "${FILE}" ]]; then
+    debug "${FILE} is the Ansible directory"
+    return 0
+  else
+    debug "${FILE} is not the Ansible directory"
+    return 1
+  fi
+}
+export -f IsAnsibleDirectory

--- a/lib/functions/validation.sh
+++ b/lib/functions/validation.sh
@@ -136,6 +136,7 @@ function GetValidationInfo() {
     ANSIBLE_DIRECTORY="${TEMP_ANSIBLE_DIRECTORY}"
     debug "Setting Ansible directory to: ${ANSIBLE_DIRECTORY}"
   fi
+  export ANSIBLE_DIRECTORY
 }
 
 function CheckIfGitBranchExists() {

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -116,7 +116,9 @@ DEFAULT_RULES_LOCATION='/action/lib/.automation'                            # De
 DEFAULT_SUPER_LINTER_WORKSPACE="/tmp/lint"                                  # Fall-back value for the workspace
 DEFAULT_WORKSPACE="${DEFAULT_WORKSPACE:-${DEFAULT_SUPER_LINTER_WORKSPACE}}" # Default workspace if running locally
 FILTER_REGEX_INCLUDE="${FILTER_REGEX_INCLUDE:-""}"
+export FILTER_REGEX_INCLUDE
 FILTER_REGEX_EXCLUDE="${FILTER_REGEX_EXCLUDE:-""}"
+export FILTER_REGEX_EXCLUDE
 GITHUB_DOMAIN="${GITHUB_DOMAIN:-"github.com"}"
 GITHUB_DOMAIN="${GITHUB_DOMAIN%/}" # Remove trailing slash if present
 # GitHub API root url

--- a/test/lib/buildFileListTest.sh
+++ b/test/lib/buildFileListTest.sh
@@ -9,21 +9,10 @@ CREATE_LOG_FILE=false
 # Default log level
 # shellcheck disable=SC2034
 LOG_LEVEL="DEBUG"
-# shellcheck disable=SC2034
-LOG_DEBUG="true"
-# shellcheck disable=SC2034
-LOG_VERBOSE="true"
-# shellcheck disable=SC2034
-LOG_NOTICE="true"
-# shellcheck disable=SC2034
-LOG_WARN="true"
-# shellcheck disable=SC2034
-LOG_ERROR="true"
 
 # shellcheck source=/dev/null
 source "lib/functions/log.sh"
 
-# shellcheck disable=SC2034
 DEFAULT_BRANCH=main
 
 git config --global init.defaultBranch "${DEFAULT_BRANCH}"
@@ -133,8 +122,51 @@ function GenerateFileDiffTwoFilesPushEventTest() {
   GenerateFileDiffTwoFilesTest "${FUNCNAME[0]}"
 }
 
+function BuildFileArraysAnsibleGitHubWorkspaceTest() {
+
+  # shellcheck source=/dev/null
+  source /action/lib/functions/detectFiles.sh
+  # shellcheck source=/dev/null
+  source /action/lib/functions/validation.sh
+
+  # shellcheck disable=SC2034
+  local FILTER_REGEX_INCLUDE=""
+  # shellcheck disable=SC2034
+  local FILTER_REGEX_EXCLUDE=""
+  # shellcheck disable=SC2034
+  local TEST_CASE_RUN=false
+  # shellcheck disable=SC2034
+  local IGNORE_GENERATED_FILES=false
+  local FILE_ARRAYS_DIRECTORY_PATH="/tmp/super-linter-file-arrays"
+  mkdir -p "${FILE_ARRAYS_DIRECTORY_PATH}"
+
+  # shellcheck disable=SC2034
+  CHECKOV_LINTER_RULES="$(mktemp)"
+
+  GITHUB_WORKSPACE="/tmp/lint"
+  # shellcheck disable=SC2034
+  ANSIBLE_DIRECTORY="${GITHUB_WORKSPACE}"
+
+  BuildFileArrays "${GITHUB_WORKSPACE}"
+
+  local FILE_ARRAY_ANSIBLE_PATH="${FILE_ARRAYS_DIRECTORY_PATH}/file-array-ANSIBLE"
+  if [[ ! -e "${FILE_ARRAY_ANSIBLE_PATH}" ]]; then
+    fatal "${FILE_ARRAY_ANSIBLE_PATH} doesn't exist"
+  fi
+
+  if ! grep -qxF "${ANSIBLE_DIRECTORY}" "${FILE_ARRAY_ANSIBLE_PATH}"; then
+    fatal "${FILE_ARRAY_ANSIBLE_PATH} doesn't contain ${ANSIBLE_DIRECTORY}"
+  fi
+
+  local FUNCTION_NAME
+  FUNCTION_NAME="${FUNCNAME[0]}"
+  notice "${FUNCTION_NAME} PASS"
+}
+
 GenerateFileDiffOneFileTest
 GenerateFileDiffOneFilePushEventTest
 GenerateFileDiffTwoFilesTest
 GenerateFileDiffTwoFilesPushEventTest
 GenerateFileDiffInitialCommitPushEventTest
+
+BuildFileArraysAnsibleGitHubWorkspaceTest

--- a/test/lib/detectFilesTest.sh
+++ b/test/lib/detectFilesTest.sh
@@ -5,15 +5,7 @@ set -o nounset
 set -o pipefail
 
 # shellcheck disable=SC2034
-LOG_DEBUG="true"
-# shellcheck disable=SC2034
-LOG_VERBOSE="true"
-# shellcheck disable=SC2034
-LOG_NOTICE="true"
-# shellcheck disable=SC2034
-LOG_WARN="true"
-# shellcheck disable=SC2034
-LOG_ERROR="true"
+LOG_LEVEL="DEBUG"
 
 # shellcheck source=/dev/null
 source "lib/functions/log.sh"
@@ -102,9 +94,29 @@ function RecognizeShebangWithBlankTest() {
   notice "${FUNCTION_NAME} PASS"
 }
 
+function IsAnsibleDirectoryTest() {
+  local GITHUB_WORKSPACE
+  GITHUB_WORKSPACE="$(mktemp -d)"
+  local FILE="${GITHUB_WORKSPACE}/ansible"
+  mkdir -p "${FILE}"
+  local ANSIBLE_DIRECTORY="/ansible"
+  export ANSIBLE_DIRECTORY
+
+  debug "Confirming that ${FILE} is an Ansible directory"
+
+  if ! IsAnsibleDirectory "${FILE}"; then
+    fatal "${FILE} is not considered to be an Ansible directory"
+  fi
+
+  FUNCTION_NAME="${FUNCNAME[0]}"
+  notice "${FUNCTION_NAME} PASS"
+}
+
 RecognizeNoShebangTest
 RecognizeCommentIsNotShebangTest
 RecognizeIndentedShebangAsCommentTest
 RecognizeSecondLineShebangAsCommentTest
 RecognizeShebangTest
 RecognizeShebangWithBlankTest
+
+IsAnsibleDirectoryTest

--- a/test/lib/githubEventTest.sh
+++ b/test/lib/githubEventTest.sh
@@ -9,16 +9,6 @@ CREATE_LOG_FILE=false
 # Default log level
 # shellcheck disable=SC2034
 LOG_LEVEL="DEBUG"
-# shellcheck disable=SC2034
-LOG_DEBUG="true"
-# shellcheck disable=SC2034
-LOG_VERBOSE="true"
-# shellcheck disable=SC2034
-LOG_NOTICE="true"
-# shellcheck disable=SC2034
-LOG_WARN="true"
-# shellcheck disable=SC2034
-LOG_ERROR="true"
 
 # shellcheck source=/dev/null
 source "lib/functions/log.sh"

--- a/test/lib/setupSSHTest.sh
+++ b/test/lib/setupSSHTest.sh
@@ -9,18 +9,6 @@ CREATE_LOG_FILE=false
 # Default log level
 # shellcheck disable=SC2034
 LOG_LEVEL="DEBUG"
-# shellcheck disable=SC2034
-LOG_TRACE="true"
-# shellcheck disable=SC2034
-LOG_DEBUG="true"
-# shellcheck disable=SC2034
-LOG_VERBOSE="true"
-# shellcheck disable=SC2034
-LOG_NOTICE="true"
-# shellcheck disable=SC2034
-LOG_WARN="true"
-# shellcheck disable=SC2034
-LOG_ERROR="true"
 
 # shellcheck source=/dev/null
 source "lib/functions/log.sh"

--- a/test/lib/validationTest.sh
+++ b/test/lib/validationTest.sh
@@ -9,16 +9,6 @@ CREATE_LOG_FILE=false
 # Default log level
 # shellcheck disable=SC2034
 LOG_LEVEL="DEBUG"
-# shellcheck disable=SC2034
-LOG_DEBUG="true"
-# shellcheck disable=SC2034
-LOG_VERBOSE="true"
-# shellcheck disable=SC2034
-LOG_NOTICE="true"
-# shellcheck disable=SC2034
-LOG_WARN="true"
-# shellcheck disable=SC2034
-LOG_ERROR="true"
 
 # shellcheck source=/dev/null
 source "lib/functions/log.sh"


### PR DESCRIPTION
# Proposed changes

Don't skip processing the current item (`FILE`) before we give `BuildFileArrays` the chance to process it as an item to eventually add to the list of directories to lint with ansible-lint.

Fix #5789

Other related changes

- Add a new make target to open a shell in a Super-linter container.
- Use a fixed path for FILE_ARRAYS_DIRECTORY_PATH so we can verify its  contents in tests
- Remove redundant ValidateBooleanVariable in buildFileList because we already check those variables in valudation.
- Move Ansible directory detection to a function so we can reuse it.
- Add missing exports for global configuration variables.
- Remove unused LOG_XXXX variables from tests. These should have been deleted when we moved log variables to log.sh

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches with the version that release-please proposes.
