### PR TITLE
ci: check for skipped and cancelled matrix jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,7 @@ jobs:
   # having to select each individual job that dynamically add to the test matrix.
   test-success-placeholder:
     name: Check if all the tests passed
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -266,10 +267,10 @@ jobs:
       - test-local-action
     steps:
       - name: Test suite success
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        if: ${{ !(contains(needs.*.result, 'failure')) && !contains(needs.*.result, 'cancelled') && !contains(needs.*.result, 'skipped') }}
         run: exit 0
       - name: Test suite failures
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
         run: exit 1
 
   preview-release-notes:


### PR DESCRIPTION
# Proposed changes

- Always run the job to check if any job of the test matrix failed.
- Check if any job of the test matrix was skipped or cancelled, and not just failed.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches with the version that release-please proposes.
