### PR TITLE
ci: print info about the environment, image size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,10 @@ jobs:
           docker load --input /tmp/${{ env.CONTAINER_IMAGE_OUTPUT_IMAGE_NAME }}.tar
           docker image ls -a
 
+      - name: Print environment info
+        run: |
+          make info
+
       - name: Update action.yml
         run: |
           echo "yq version: $(yq --version)"

--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,6 @@ ifeq ($(INTERACTIVE), 1)
 	DOCKER_FLAGS += -t
 endif
 
-.PHONY: info
-info: ## Gather information about the runtime environment
-	echo "whoami: $$(whoami)"; \
-	echo "pwd: $$(pwd)"; \
-	echo "ls -ahl: $$(ls -ahl)"; \
-	docker images; \
-	docker ps
-
 .PHONY: help
 help: ## Show help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -79,12 +71,28 @@ endif
 
 DEV_CONTAINER_URL := "super-linter/dev-container:latest"
 
-
 ifeq ($(GITHUB_HEAD_REF),)
 RELEASE_PLEASE_TARGET_BRANCH := "$(shell git branch --show-current)"
 else
 RELEASE_PLEASE_TARGET_BRANCH := "${GITHUB_HEAD_REF}"
 endif
+
+.PHONY: info
+info: ## Gather information about the runtime environment
+	echo "whoami: $$(whoami)"; \
+	echo "pwd: $$(pwd)"; \
+	echo "IMAGE:" $(IMAGE) \
+	echo "SUPER_LINTER_TEST_CONTAINER_URL:" $(SUPER_LINTER_TEST_CONTAINER_URL) \
+	echo "ls -ahl: $$(ls -ahl)"; \
+	docker images; \
+	docker ps; \
+	echo "Container image layers size:"; \
+	docker history \
+		--human \
+		--no-trunc \
+		--format "{{.Size}} {{.CreatedSince}} {{.CreatedBy}}" \
+		$(SUPER_LINTER_TEST_CONTAINER_URL) \
+		| sort --human
 
 .PHONY: check-github-token
 check-github-token:


### PR DESCRIPTION
# Proposed changes

- Add information about container image layers size when printing info about the environment.
- Print info about the environment during the CI job.

This is helpful for #5630

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [ ] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches with the version that release-please proposes.
