### PR TITLE
ci: enable dev-dependencies docker build checks

### DIFF
--- a/dev-dependencies/Dockerfile
+++ b/dev-dependencies/Dockerfile
@@ -29,4 +29,4 @@ ARG UID=1000
 ARG GID=1000
 RUN groupadd -g ${GID} -o "${USERNAME}" \
   && useradd -m -u ${UID} -g ${GID} -o -s /bin/bash -l "${USERNAME}"
-USER $UNAME
+USER $USERNAME


### PR DESCRIPTION
# Proposed changes

- Run Docker build checks when building the dev-dependencies container
  image and when running the test target.
- Run Docker build checks when building the Super-linter container, and
  not just when running the test target.
- Use the correct variable when setting the dev-dependencies container
  user.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches with the version that release-please proposes.
