### PR TITLE
ci: authenticate tflint init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ ENV TFLINT_PLUGIN_DIR="/root/.tflint.d/plugins"
 COPY TEMPLATES/.tflint.hcl /action/lib/.automation/
 
 # Initialize TFLint plugins so we get plugin versions listed when we ask for TFLint version
-RUN tflint --init -c /action/lib/.automation/.tflint.hcl
+RUN --mount=type=secret,id=GITHUB_TOKEN GITHUB_TOKEN=$(cat /run/secrets/GITHUB_TOKEN) tflint --init -c /action/lib/.automation/.tflint.hcl
 
 FROM python:3.12.3-alpine3.20 AS lintr-installer
 


### PR DESCRIPTION
# Proposed changes

TFLint init might hit an API rate limit, especially when requests to the TFLint backend come from shared tenants, such as GitHub Actions.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches with the version that release-please proposes.
