### PR TITLE
chore: update dependabot config for ci/dev updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ version: 2
 updates:
 
   - package-ecosystem: "devcontainers"
+    commit-message:
+      prefix: "chore(devcontainer)"
     directory: "/"
     schedule:
       interval: weekly
@@ -13,7 +15,7 @@ updates:
 
   - package-ecosystem: github-actions
     commit-message:
-      prefix: "deps(github-actions)"
+      prefix: "ci(github-actions)"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -77,7 +79,7 @@ updates:
 
   - package-ecosystem: "docker"
     commit-message:
-      prefix: "deps(dev-docker)"
+      prefix: "ci(dev-docker)"
     directory: "/dev-dependencies"
     schedule:
       interval: "weekly"
@@ -85,7 +87,7 @@ updates:
 
   - package-ecosystem: "npm"
     commit-message:
-      prefix: "deps(dev-npm)"
+      prefix: "ci(dev-npm)"
     directory: "/dev-dependencies"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
# Proposed changes

Move internal-facing dependency updates out of the main changelog:

- Categorize GitHub Actions and dev dependency updates under the 'ci' prefix.
- Categorize devcontainers updates under the 'chore' prefix.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches with the version that release-please proposes.
