### PR TITLE
fix: update pylint to ignore import-errors

### DIFF
--- a/TEMPLATES/.python-lint
+++ b/TEMPLATES/.python-lint
@@ -2,3 +2,10 @@
 
 # Use multiple processes to speed up Pylint.
 jobs=0
+
+[MESSAGES CONTROL]
+
+# Ignoring Import Errors is desired as super-linter
+# does not support installing dependencies as it runs
+disable=import-error
+

--- a/test/linters/python_pylint/python_good_2.py
+++ b/test/linters/python_pylint/python_good_2.py
@@ -1,0 +1,5 @@
+"""Test Python file for Pylint."""
+
+import pytest
+
+print(pytest)


### PR DESCRIPTION
Adds back import-error to the pylint disable rules that was removed as of: https://github.com/super-linter/super-linter/pull/5252

Fix #5926

# Proposed changes

update .python-lint to include `disable=import-error`

Also adds a new test case for import errors

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [ ] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [X] I provided the necessary tests.
- [X] I squashed all the commits into a single commit.
- [X] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [N/A] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [X] If this pull request is about and existing issue,
- [X] I added the `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches with the version that release-please proposes.
