### PR TITLE
feat: support ignore_gitignored_files with jscpd

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -107,7 +107,7 @@ This section helps you upgrade from super-linter `v5` to `v6`.
   entire workspace instead of linting files one by one. You can safely remove
   the `VALIDATE_JSCPD_ALL_CODEBASE` variable from your configuration.
 - Jscpd doesn't consider the `FILTER_REGEX_EXCLUDE`, `FILTER_REGEX_INCLUDE`,
-  `IGNORE_GENERATED_FILES`, `IGNORE_GITIGNORED_FILES` variables. For more
+  `IGNORE_GENERATED_FILES` variables. For more
   information about how to ignore files with Jscpd, see
   [the Jscpd documentation](https://github.com/kucherenko/jscpd/tree/master/packages/jscpd).
 

--- a/lib/functions/linterCommands.sh
+++ b/lib/functions/linterCommands.sh
@@ -65,6 +65,13 @@ LINTER_COMMANDS_ARRAY_JAVASCRIPT_ES=(eslint -c "${JAVASCRIPT_ES_LINTER_RULES}")
 LINTER_COMMANDS_ARRAY_JAVASCRIPT_STANDARD=(standard "${JAVASCRIPT_STANDARD_LINTER_RULES}")
 LINTER_COMMANDS_ARRAY_JAVASCRIPT_PRETTIER=(prettier --check)
 LINTER_COMMANDS_ARRAY_JSCPD=(jscpd --config "${JSCPD_LINTER_RULES}")
+JSCPD_GITIGNORE_OPTION="--gitignore"
+if [[ "${IGNORE_GITIGNORED_FILES}" == "true" ]]; then
+  debug "IGNORE_GITIGNORED_FILES is ${IGNORE_GITIGNORED_FILES}. Enable Jscpd option to ignore files that Git ignores (${JSCPD_GITIGNORE_OPTION})"
+  # Users can also add the '"gitignore": true' option in their Jscpd config files to achieve the same functionality
+  # but we want to respect IGNORE_GITIGNORED_FILES
+  LINTER_COMMANDS_ARRAY_JSCPD+=("${JSCPD_GITIGNORE_OPTION}")
+fi
 LINTER_COMMANDS_ARRAY_JSON=(eslint -c "${JAVASCRIPT_ES_LINTER_RULES}" --ext '.json')
 LINTER_COMMANDS_ARRAY_JSONC=(eslint -c "${JAVASCRIPT_ES_LINTER_RULES}" --ext '.json5,.jsonc')
 LINTER_COMMANDS_ARRAY_JSX=(eslint -c "${JSX_LINTER_RULES}")

--- a/test/lib/linterCommandsTest.sh
+++ b/test/lib/linterCommandsTest.sh
@@ -71,4 +71,45 @@ function LinterCommandPresenceTest() {
   notice "${FUNCTION_NAME} PASS"
 }
 
+function IgnoreGitIgnoredFilesJscpdCommandTest() {
+  local FUNCTION_NAME
+  FUNCTION_NAME="${FUNCNAME[0]}"
+  info "${FUNCTION_NAME} start"
+
+  # shellcheck disable=SC2034
+  IGNORE_GITIGNORED_FILES="true"
+
+  # Source the file again so it accounts for modifications
+  # shellcheck source=/dev/null
+  source "lib/functions/linterCommands.sh"
+
+  EXPECTED_COMMAND=("${LINTER_COMMANDS_ARRAY_JSCPD[@]}" "${JSCPD_GITIGNORE_OPTION}")
+
+  if [[ "${LINTER_COMMANDS_ARRAY_JSCPD[*]}" == "${EXPECTED_COMMAND[*]}" ]]; then
+    debug "Command (${LINTER_COMMANDS_ARRAY_JSCPD[*]}) matches with the expected one (${EXPECTED_COMMAND[*]})"
+  fi
+
+  notice "${FUNCTION_NAME} PASS"
+}
+
+function JscpdCommandTest() {
+  local FUNCTION_NAME
+  FUNCTION_NAME="${FUNCNAME[0]}"
+  info "${FUNCTION_NAME} start"
+
+  # Source the file again so it accounts for modifications
+  # shellcheck source=/dev/null
+  source "lib/functions/linterCommands.sh"
+
+  EXPECTED_COMMAND=(jscpd --config "${JSCPD_LINTER_RULES}")
+
+  if [[ "${LINTER_COMMANDS_ARRAY_JSCPD[*]}" == "${EXPECTED_COMMAND[*]}" ]]; then
+    debug "Command (${LINTER_COMMANDS_ARRAY_JSCPD[*]}) matches with the expected one (${EXPECTED_COMMAND[*]})"
+  fi
+
+  notice "${FUNCTION_NAME} PASS"
+}
+
 LinterCommandPresenceTest
+IgnoreGitIgnoredFilesJscpdCommandTest
+JscpdCommandTest


### PR DESCRIPTION
# Proposed changes

Add the --gitignore option to LINTER_COMMANDS_ARRAY_JSCPD when
IGNORE_GITIGNORED_FILES=true. Users can also set the gitignore options
in the Jscpd configuration file, but with this change we make Jscpd
automatically respecting that.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches with the version that release-please proposes.
