### PR TITLE
feat: local fix mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,7 @@ test/reports
 # Test leftovers
 .lintr
 test/linters/rust_clippy/**/Cargo.lock
-test/linters/rust_clippy/**/target/**
+test/linters/rust_clippy/**/target
 
 # Super-linter ouputs
 super-linter-output/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Super-Linter
 
 Super-linter is a ready-to-run collection of linters and code analyzers, to
-help validate your source code.
+help validate and fix your source code.
 
 The goal of super-linter is to help you establish best practices and consistent
 formatting across multiple programming languages, and ensure developers are
@@ -11,6 +11,8 @@ Super-linter analyzes source code files using several tools, and reports the
 issues that those tools find as console output, and as
 [GitHub Actions status checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks).
 You can also [run super-linter outside GitHub Actions](#run-super-linter-outside-github-actions).
+
+Super-linter can also help you [fix linting and formatting issues](#fix-linting-and-formatting-issues).
 
 Super-linter is licensed under an
 [MIT License](https://github.com/super-linter/super-linter/blob/main/LICENSE).
@@ -183,9 +185,9 @@ Super-Linter provides several variants:
   - `pwsh` linters
   - `c#` linters
 
-## Configure super-linter
+## Configure Super-linter
 
-You can configure super-linter using the following environment variables:
+You can configure Super-linter using the following environment variables:
 
 | **Environment variable**                        | **Default Value**               | **Description**                                                                                                                                                                                                      |
 |-------------------------------------------------|---------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -207,6 +209,41 @@ You can configure super-linter using the following environment variables:
 | **ENABLE_GITHUB_ACTIONS_STEP_SUMMARY**          | `false` if `RUN_LOCAL=true`, `true` otherwise | Flag to enable [GitHub Actions job summary](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary) for the Super-linter action. For more information, see [Summary outputs](#summary-outputs). |
 | **FILTER_REGEX_EXCLUDE**                        | not set                         | Regular expression defining which files will be excluded from linting  (ex: `.*src/test.*`). Not setting this variable means to process all files.                                                                   |
 | **FILTER_REGEX_INCLUDE**                        | not set                         | Regular expression defining which files will be processed by linters (ex: `.*src/.*`). Not setting this variable means to process all files. `FILTER_REGEX_INCLUDE` is evaluated before `FILTER_REGEX_EXCLUDE`.      |
+| **FIX_ANSIBLE**                                 | `false`                         | Option to enable fix mode for `ANSIBLE`.                                                                                                                                                                             |
+| **FIX_CLANG_FORMAT**                            | `false`                         | Option to enable fix mode for `CLANG_FORMAT`.                                                                                                                                                                        |
+| **FIX_CSHARP**                                  | `false`                         | Option to enable fix mode for `CSHARP`.                                                                                                                                                                              |
+| **FIX_CSS**                                     | `false`                         | Option to enable fix mode for `CSS`.                                                                                                                                                                                 |
+| **FIX_ENV**                                     | `false`                         | Option to enable fix mode for `ENV`.                                                                                                                                                                                 |
+| **FIX_GO**                                      | `false`                         | Option to enable fix mode for `GO`.                                                                                                                                                                                  |
+| **FIX_GO_MODULES**                              | `false`                         | Option to enable fix mode for `GO_MODULES`.                                                                                                                                                                          |
+| **FIX_GOOGLE_JAVA_FORMAT**                      | `false`                         | Option to enable fix mode for `GOOGLE_JAVA_FORMAT`.                                                                                                                                                                  |
+| **FIX_GROOVY**                                  | `false`                         | Option to enable fix mode for `GROOVY`.                                                                                                                                                                              |
+| **FIX_JAVASCRIPT_ES**                           | `false`                         | Option to enable fix mode for `JAVASCRIPT_ES`.                                                                                                                                                                       |
+| **FIX_JAVASCRIPT_PRETTIER**                     | `false`                         | Option to enable fix mode for `JAVASCRIPT_PRETTIER`.                                                                                                                                                                 |
+| **FIX_JAVASCRIPT_STANDARD**                     | `false`                         | Option to enable fix mode for `JAVASCRIPT_STANDARD`.                                                                                                                                                                 |
+| **FIX_JSON**                                    | `false`                         | Option to enable fix mode for `JSON`.                                                                                                                                                                                |
+| **FIX_JSONC**                                   | `false`                         | Option to enable fix mode for `JSONC`.                                                                                                                                                                               |
+| **FIX_JSX**                                     | `false`                         | Option to enable fix mode for `JSX`.                                                                                                                                                                                 |
+| **FIX_MARKDOWN**                                | `false`                         | Option to enable fix mode for `MARKDOWN`.                                                                                                                                                                            |
+| **FIX_POWERSHELL**                              | `false`                         | Option to enable fix mode for `POWERSHELL`.                                                                                                                                                                          |
+| **FIX_PROTOBUF**                                | `false`                         | Option to enable fix mode for `PROTOBUF`.                                                                                                                                                                            |
+| **FIX_PYTHON_BLACK**                            | `false`                         | Option to enable fix mode for `PYTHON_BLACK`.                                                                                                                                                                        |
+| **FIX_PYTHON_ISORT**                            | `false`                         | Option to enable fix mode for `PYTHON_ISORT`.                                                                                                                                                                        |
+| **FIX_PYTHON_RUFF**                             | `false`                         | Option to enable fix mode for `PYTHON_RUFF`.                                                                                                                                                                         |
+| **FIX_RUBY**                                    | `false`                         | Option to enable fix mode for `RUBY`.                                                                                                                                                                                |
+| **FIX_RUST_2015**                               | `false`                         | Option to enable fix mode for `RUST_2015`.                                                                                                                                                                           |
+| **FIX_RUST_2018**                               | `false`                         | Option to enable fix mode for `RUST_2018`.                                                                                                                                                                           |
+| **FIX_RUST_2021**                               | `false`                         | Option to enable fix mode for `RUST_2021`.                                                                                                                                                                           |
+| **FIX_RUST_CLIPPY**                             | `false`                         | Option to enable fix mode for `RUST_CLIPPY`.                                                                                                                                                                         |
+| **FIX_SCALAFMT**                                | `false`                         | Option to enable fix mode for `SCALAFMT`.                                                                                                                                                                            |
+| **FIX_SHELL_SHFMT**                             | `false`                         | Option to enable fix mode for `SHELL_SHFMT`.                                                                                                                                                                         |
+| **FIX_SNAKEMAKE_SNAKEFMT**                      | `false`                         | Option to enable fix mode for `SNAKEMAKE_SNAKEFMT`.                                                                                                                                                                  |
+| **FIX_SQLFLUFF**                                | `false`                         | Option to enable fix mode for `SQLFLUFF`.                                                                                                                                                                            |
+| **FIX_TERRAFORM_FMT**                           | `false`                         | Option to enable fix mode for `TERRAFORM_FMT`.                                                                                                                                                                       |
+| **FIX_TSX**                                     | `false`                         | Option to enable fix mode for `TSX`.                                                                                                                                                                                 |
+| **FIX_TYPESCRIPT_ES**                           | `false`                         | Option to enable fix mode for `TYPESCRIPT_ES`.                                                                                                                                                                       |
+| **FIX_TYPESCRIPT_PRETTIER**                     | `false`                         | Option to enable fix mode for `TYPESCRIPT_PRETTIER`.                                                                                                                                                                 |
+| **FIX_TYPESCRIPT_STANDARD**                     | `false`                         | Option to enable fix mode for `TYPESCRIPT_STANDARD`.                                                                                                                                                                 |
 | **GITHUB_ACTIONS_CONFIG_FILE**                  | `actionlint.yml`                | Filename for [Actionlint configuration](https://github.com/rhysd/actionlint/blob/main/docs/config.md) (ex: `actionlint.yml`)                                                                                         |
 | **GITHUB_ACTIONS_COMMAND_ARGS**                 | `null`                          | Additional arguments passed to `actionlint` command. Useful to [ignore some errors](https://github.com/rhysd/actionlint/blob/main/docs/usage.md#ignore-some-errors)                                                  |
 | **GITHUB_CUSTOM_API_URL**                       | `https://api.${GITHUB_DOMAIN}`  | Specify a custom GitHub API URL in case GitHub Enterprise is used: e.g. `https://github.myenterprise.com/api/v3`                                                                                                     |
@@ -351,9 +388,38 @@ The `VALIDATE_[LANGUAGE]` variables work as follows:
 - If you set any of the `VALIDATE_[LANGUAGE]` variables to `false`, super-linter defaults to leaving any unset variable to true (only exclude those languages).
 - If you set any of the `VALIDATE_[LANGUAGE]` variables to both `true` and `false`, super-linter fails reporting an error.
 
-For more information about reusing super-linter configuration across
+For more information about reusing Super-linter configuration across
 environments, see
 [Share Environment variables between environments](docs/run-linter-locally.md#share-environment-variables-between-environments).
+
+## Fix linting and formatting issues
+
+All the linters and formatters that Super-linter runs report errors if they
+detect linting or formatting issues without modifying your source
+code (_check only mode_). Check only mode is the default for all linters and
+formatters that Super-linter runs.
+
+Certain linters and formatters support automatically fixing issues in your code
+(_fix mode_). You can enable fix mode for a particular linter or formatter by
+setting the relevant `FIX_<language name>` variable to `true`. To know which
+linters and formatters support fix mode, refer to the
+[Configure Super-linter section](#configure-super-linter).
+
+Setting a `FIX_<language name>` variable to `true` implies setting the
+corresponding `VALIDATE_<language name>` to `true`. Setting a
+`FIX_<language name>` variable to `true` and the corresponding
+`VALIDATE_<language name>` to `false` is a configuration error. Super-linter
+reports that as a fatal error.
+
+Super-linter supports the following locations to deliver fixes:
+
+- In the current Super-linter workspace, so you can process the changes to your
+  files by yourself. For example:
+
+  - If you're running Super-linter in your CI environment, such as GitHub
+      Actions, you can commit and push changes as part of your workflow.
+  - If you're running Super-linter locally, you can commit the changes as you
+      would with any other change in your working directory.
 
 ## Configure linters
 

--- a/docs/run-linter-locally.md
+++ b/docs/run-linter-locally.md
@@ -139,3 +139,12 @@ To get the list of the available `Make` targets, run the following command:
 ```shell
 make help
 ```
+
+### Automatically fix formatting and linting issues
+
+To automatically fix linting and formatting issues when supported, run the
+following command:
+
+```shell
+make fix-codebase
+```

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -39,17 +39,14 @@ This section helps you upgrade from super-linter `v6.7.0` to `v6.8.0`.
 
     - If you set `JAVASCRIPT_DEFAULT_STYLE=standard`, set
       `VALIDATE_JAVASCRIPT_PRETTIER=false`
-
     - If you set `TYPESCRIPT_DEFAULT_STYLE=standard`, set
       `VALIDATE_TYPESCRIPT_PRETTIER=false`
-
     - If you set `JAVASCRIPT_DEFAULT_STYLE=prettier`, set
       `VALIDATE_JAVASCRIPT_STANDARD=false`
-
     - If you set `TYPESCRIPT_DEFAULT_STYLE=prettier`, set
       `VALIDATE_TYPESCRIPT_STANDARD=false`
 
-  Finally, you remove both `JAVASCRIPT_DEFAULT_STYLE` and
+  Finally, remove both `JAVASCRIPT_DEFAULT_STYLE` and
   `TYPESCRIPT_DEFAULT_STYLE` from your Super-linter configuration.
 
 ## Upgrade from v5 to v6

--- a/lib/functions/worker.sh
+++ b/lib/functions/worker.sh
@@ -142,6 +142,16 @@ function LintCodebase() {
 
   # shellcheck source=/dev/null
   source /action/lib/functions/linterCommands.sh
+  # Dynamically add arguments and commands to each linter command as needed
+  if ! InitFixModeOptionsAndCommands "${FILE_TYPE}"; then
+    fatal "Error while inizializing fix mode and check only options and commands before running linter for ${FILE_TYPE}"
+  fi
+  InitInputConsumeCommands
+
+  if [[ "${FILE_TYPE}" == "POWERSHELL" ]]; then
+    debug "Language: ${FILE_TYPE}. Initialize PowerShell command"
+    InitPowerShellCommand
+  fi
 
   local -n LINTER_COMMAND_ARRAY
   LINTER_COMMAND_ARRAY="LINTER_COMMANDS_ARRAY_${FILE_TYPE}"

--- a/lib/globals/linterCommandsOptions.sh
+++ b/lib/globals/linterCommandsOptions.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2034 # Disable ununsed variables warning because we
+# source this script and use these variables as globals
+
+# "check only" mode options for linters that that we reuse across several languages
+PRETTIER_CHECK_ONLY_MODE_OPTIONS=(--check)
+RUSTFMT_CHECK_ONLY_MODE_OPTIONS=(--check)
+
+# Define configuration options to enable "check only" mode.
+# Some linters and formatters only support a "check only" mode so there's no
+# need to define a "check only" mode option for those.
+CLANG_FORMAT_CHECK_ONLY_MODE_OPTIONS=(--dry-run)
+CSHARP_CHECK_ONLY_MODE_OPTIONS=(--verify-no-changes)
+GOOGLE_JAVA_FORMAT_CHECK_ONLY_MODE_OPTIONS=(--dry-run --set-exit-if-changed)
+JAVASCRIPT_PRETTIER_CHECK_ONLY_MODE_OPTIONS=("${PRETTIER_CHECK_ONLY_MODE_OPTIONS[@]}")
+PYTHON_BLACK_CHECK_ONLY_MODE_OPTIONS=(--diff --check)
+PYTHON_ISORT_CHECK_ONLY_MODE_OPTIONS=(--diff --check)
+RUST_2015_CHECK_ONLY_MODE_OPTIONS=("${RUSTFMT_CHECK_ONLY_MODE_OPTIONS[@]}")
+RUST_2018_CHECK_ONLY_MODE_OPTIONS=("${RUSTFMT_CHECK_ONLY_MODE_OPTIONS[@]}")
+RUST_2021_CHECK_ONLY_MODE_OPTIONS=("${RUSTFMT_CHECK_ONLY_MODE_OPTIONS[@]}")
+SCALAFMT_CHECK_ONLY_MODE_OPTIONS=(--test)
+SHELL_SHFMT_CHECK_ONLY_MODE_OPTIONS=(--diff)
+SNAKEMAKE_SNAKEFMT_CHECK_ONLY_MODE_OPTIONS=(--check --compact-diff)
+SQLFLUFF_CHECK_ONLY_MODE_OPTIONS=(lint)
+TERRAFORM_FMT_CHECK_ONLY_MODE_OPTIONS=(-check -diff)
+TYPESCRIPT_PRETTIER_CHECK_ONLY_MODE_OPTIONS=("${PRETTIER_CHECK_ONLY_MODE_OPTIONS[@]}")
+
+# Fix mode options for linters that that we reuse across several languages
+ESLINT_FIX_MODE_OPTIONS=(--fix)
+GOLANGCI_LINT_FIX_MODE_OPTIONS=(--fix)
+PRETTIER_FIX_MODE_OPTIONS=(--write)
+STANDARD_FIX_MODE_OPTIONS=(--fix)
+
+# Define configuration options to enable "fix mode".
+# Not all linters and formatters support this.
+ANSIBLE_FIX_MODE_OPTIONS=(--fix)
+CSS_FIX_MODE_OPTIONS=(--fix)
+ENV_FIX_MODE_OPTIONS=(fix)
+GO_FIX_MODE_OPTIONS=("${GOLANGCI_LINT_FIX_MODE_OPTIONS[@]}")
+GO_MODULES_FIX_MODE_OPTIONS=("${GOLANGCI_LINT_FIX_MODE_OPTIONS[@]}")
+GROOVY_FIX_MODE_OPTIONS=(--fix)
+JAVASCRIPT_ES_FIX_MODE_OPTIONS=("${ESLINT_FIX_MODE_OPTIONS[@]}")
+JAVASCRIPT_PRETTIER_FIX_MODE_OPTIONS=("${PRETTIER_FIX_MODE_OPTIONS[@]}")
+JAVASCRIPT_STANDARD_FIX_MODE_OPTIONS=("${STANDARD_FIX_MODE_OPTIONS[@]}")
+JSON_FIX_MODE_OPTIONS=("${ESLINT_FIX_MODE_OPTIONS[@]}")
+JSONC_FIX_MODE_OPTIONS=("${ESLINT_FIX_MODE_OPTIONS[@]}")
+JSX_FIX_MODE_OPTIONS=("${ESLINT_FIX_MODE_OPTIONS[@]}")
+MARKDOWN_FIX_MODE_OPTIONS=(--fix)
+POWERSHELL_FIX_MODE_OPTIONS=(-Fix)
+PROTOBUF_FIX_MODE_OPTIONS=(-fix)
+PYTHON_RUFF_FIX_MODE_OPTIONS=(--fix)
+RUBY_FIX_MODE_OPTIONS=(--autocorrect)
+RUST_CLIPPY_FIX_MODE_OPTIONS=(--fix)
+SHELL_SHFMT_FIX_MODE_OPTIONS=(--write)
+SQLFLUFF_FIX_MODE_OPTIONS=(fix)
+TSX_FIX_MODE_OPTIONS=("${ESLINT_FIX_MODE_OPTIONS[@]}")
+TYPESCRIPT_ES_FIX_MODE_OPTIONS=("${ESLINT_FIX_MODE_OPTIONS[@]}")
+TYPESCRIPT_PRETTIER_FIX_MODE_OPTIONS=("${PRETTIER_FIX_MODE_OPTIONS[@]}")
+TYPESCRIPT_STANDARD_FIX_MODE_OPTIONS=("${STANDARD_FIX_MODE_OPTIONS[@]}")
+
+# sqlfluff is a special case because it needs a different subcommand and
+# subcommand options
+SQLFLUFF_SHARED_SUBCOMMAND_OPTIONS=(--config "${SQLFLUFF_LINTER_RULES}")
+SQLFLUFF_CHECK_ONLY_MODE_OPTIONS+=("${SQLFLUFF_SHARED_SUBCOMMAND_OPTIONS[@]}")
+SQLFLUFF_FIX_MODE_OPTIONS+=("${SQLFLUFF_SHARED_SUBCOMMAND_OPTIONS[@]}")
+
+# If there's no input argument, GNU Parallel adds a default {} at the end of the
+# command it runs. In a few cases, such as ANSIBLE, GO_MODULES, and RUST_CLIPPY,
+# consume the {} element by artifically adding it to the command to run because
+# we need the input to set the working directory, but we don't need it appended
+# at the end of the command.
+# Setting the -n 0 GNU Parallel would not help in this case, because the input
+# will not be passed to the --workdir option as well.
+INPUT_CONSUME_COMMAND=("&& echo \"Linted: {}\"")

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -788,6 +788,18 @@ done
 # Load rules for special cases
 GetStandardRules "javascript"
 
+#############################################################################
+# Validate the environment that depends on linter rules variables being set #
+#############################################################################
+
+# We need the variables defined in linterCommandsOptions to initialize FIX_....
+# variables.
+# shellcheck source=/dev/null
+source /action/lib/globals/linterCommandsOptions.sh
+if ! ValidateCheckModeAndFixModeVariables; then
+  fatal "Error while validating the configuration fix mode for linters that support that"
+fi
+
 #################################
 # Check for SSL cert and update #
 #################################

--- a/test/inspec/super-linter/controls/super_linter.rb
+++ b/test/inspec/super-linter/controls/super_linter.rb
@@ -475,6 +475,7 @@ control "super-linter-validate-files" do
     "/action/lib/functions/validation.sh",
     "/action/lib/functions/worker.sh",
     "/action/lib/globals/languages.sh",
+    "/action/lib/globals/linterCommandsOptions.sh",
     "/action/lib/globals/linterRules.sh",
     "/action/lib/.automation/actionlint.yml",
     "/action/lib/.automation/.ansible-lint.yml",

--- a/test/lib/validationTest.sh
+++ b/test/lib/validationTest.sh
@@ -363,7 +363,7 @@ function ValidationVariablesExportTest() {
   for LANGUAGE in "${LANGUAGE_ARRAY[@]}"; do
     local -n VALIDATE_LANGUAGE
     VALIDATE_LANGUAGE="VALIDATE_${LANGUAGE}"
-    debug "VALIDATE_LANGUAGE (${LANGUAGE}) variable attributes: ${VALIDATE_LANGUAGE@a}"
+    debug "VALIDATE_LANGUAGE (Language: ${LANGUAGE}) variable attributes: ${VALIDATE_LANGUAGE@a}"
     if [[ "${VALIDATE_LANGUAGE@a}" == *x* ]]; then
       info "VALIDATE_LANGUAGE for ${LANGUAGE} is exported as expected"
     else
@@ -371,6 +371,130 @@ function ValidationVariablesExportTest() {
     fi
     unset -n VALIDATE_LANGUAGE
   done
+
+  notice "${FUNCTION_NAME} PASS"
+}
+
+function ValidateCheckModeAndFixModeVariablesTest() {
+  local FUNCTION_NAME
+  FUNCTION_NAME="${FUNCNAME[0]}"
+  info "${FUNCTION_NAME} start"
+
+  # shellcheck disable=SC2034
+  LANGUAGE_ARRAY=('A' 'B' 'C' 'D')
+  # shellcheck disable=SC2034
+  A_FIX_MODE_OPTIONS=(--fixA)
+  # shellcheck disable=SC2034
+  A_CHECK_ONLY_MODE_OPTIONS=(--checkA)
+  # shellcheck disable=SC2034
+  B_FIX_MODE_OPTIONS=(--fixB)
+  # shellcheck disable=SC2034
+  C_CHECK_ONLY_MODE_OPTIONS=(--checkC)
+
+  # shellcheck disable=SC2034
+  VALIDATE_A="true"
+  # shellcheck disable=SC2034
+  VALIDATE_B="true"
+  # shellcheck disable=SC2034
+  VALIDATE_C="true"
+  # shellcheck disable=SC2034
+  FIX_B="true"
+
+  if ! ValidateCheckModeAndFixModeVariables; then
+    fatal "Error while validating fix mode variables"
+  fi
+
+  if [[ -v FIX_A ]]; then
+    debug "FIX_A variable is defined as expected"
+  else
+    fatal "FIX_A variable should have been defined"
+  fi
+
+  EXPECTED_FIX_A="false"
+  if [[ "${FIX_A}" == "${EXPECTED_FIX_A}" ]]; then
+    debug "FIX_A variable has the expected value: ${FIX_A}"
+  else
+    fatal "FIX_A (${FIX_A}) doesn't match with the expected value: ${EXPECTED_FIX_A}"
+  fi
+
+  if [[ -v FIX_C ]]; then
+    debug "FIX_C variable is defined as expected"
+  else
+    fatal "FIX_C variable should have been defined"
+  fi
+
+  EXPECTED_FIX_C="false"
+  if [[ "${FIX_C}" == "${EXPECTED_FIX_C}" ]]; then
+    debug "FIX_C variable has the expected value: ${FIX_C}"
+  else
+    fatal "FIX_C (${FIX_C}) doesn't match with the expected value: ${EXPECTED_FIX_C}"
+  fi
+
+  # No need to check if FIX_B is defined because we defined it earlier in this test function
+
+  if [[ ! -v FIX_D ]]; then
+    debug "FIX_D is not defined as expected"
+  else
+    fatal "FIX_D variable should have not been defined"
+  fi
+
+  debug "FIX_A variable attributes: ${FIX_A@a}"
+  if [[ "${FIX_A@a}" == *x* ]]; then
+    debug "FIX_A is exported as expected"
+  else
+    fatal "FIX_A should have been exported"
+  fi
+
+  debug "FIX_B variable attributes: ${FIX_B@a}"
+  if [[ "${FIX_B@a}" == *x* ]]; then
+    debug "FIX_B is exported as expected"
+  else
+    fatal "FIX_B should have been exported"
+  fi
+
+  debug "FIX_C variable attributes: ${FIX_C@a}"
+  if [[ "${FIX_C@a}" == *x* ]]; then
+    debug "FIX_C is exported as expected"
+  else
+    fatal "FIX_C should have been exported"
+  fi
+
+  unset FIX_A
+  unset FIX_B
+  unset FIX_C
+  unset FIX_D
+  unset VALIDATE_A
+  unset VALIDATE_B
+  unset VALIDATE_C
+
+  # shellcheck disable=SC2034
+  LANGUAGE_ARRAY=('E')
+  # shellcheck disable=SC2034
+  E_FIX_MODE_OPTIONS=(--fixA)
+  FIX_E="true"
+  VALIDATE_E="false"
+
+  if ValidateCheckModeAndFixModeVariables; then
+    fatal "FIX_E (${FIX_E}) and VALIDATE_E (${VALIDATE_E}) should have failed validation"
+  else
+    debug "FIX_E (${FIX_E}) and VALIDATE_E (${VALIDATE_E}) failed validation as expected"
+  fi
+
+  unset FIX_E
+  unset VALIDATE_E
+
+  # shellcheck disable=SC2034
+  LANGUAGE_ARRAY=('F')
+  FIX_F="true"
+
+  if ValidateCheckModeAndFixModeVariables; then
+    fatal "FIX_F (${FIX_F}) should have failed validation when it doesn't support fix mode or check only mode"
+  else
+    debug "FIX_F (${FIX_F}) failed validation as expected when it doesn't support fix mode or check only mode"
+  fi
+
+  unset FIX_F
+  unset VALIDATE_F
 
   notice "${FUNCTION_NAME} PASS"
 }
@@ -384,3 +508,4 @@ ValidateFindModeTest
 ValidateAnsibleDirectoryTest
 ValidateValidationVariablesTest
 ValidationVariablesExportTest
+ValidateCheckModeAndFixModeVariablesTest

--- a/test/linters/groovy/groovy_good_01.groovy
+++ b/test/linters/groovy/groovy_good_01.groovy
@@ -2,8 +2,10 @@
 // file name for tests.
 // groovylint-disable-next-line ClassNameSameAsFilename
 class Example {
+
     static void main(String[] args) {
-        File file = new File("E:/Example.txt")
+        File file = new File('E:/Example.txt')
         println "The file ${file.absolutePath} has ${file.length()} bytes"
     }
+
 }

--- a/test/run-super-linter-tests.sh
+++ b/test/run-super-linter-tests.sh
@@ -4,6 +4,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# shellcheck source=/dev/null
+source "test/testUtils.sh"
+
 SUPER_LINTER_TEST_CONTAINER_URL="${1}"
 TEST_FUNCTION_NAME="${2}"
 SUPER_LINTER_CONTAINER_IMAGE_TYPE="${3}"
@@ -149,6 +152,48 @@ run_test_cases_save_super_linter_output_custom_path() {
 run_test_case_custom_summary() {
   run_test_cases_expect_success
   SUPER_LINTER_SUMMARY_FILE_NAME="custom-github-step-summary.md"
+}
+
+run_test_case_fix_mode() {
+  run_test_cases_expect_success
+  CREATE_LOG_FILE="true"
+  SAVE_SUPER_LINTER_OUTPUT="true"
+
+  COMMAND_TO_RUN+=(--env FIX_ANSIBLE="true")
+  COMMAND_TO_RUN+=(--env FIX_CLANG_FORMAT="true")
+  COMMAND_TO_RUN+=(--env FIX_CSHARP="true")
+  COMMAND_TO_RUN+=(--env FIX_CSS="true")
+  COMMAND_TO_RUN+=(--env FIX_ENV="true")
+  COMMAND_TO_RUN+=(--env FIX_GO_MODULES="true")
+  COMMAND_TO_RUN+=(--env FIX_GO="true")
+  COMMAND_TO_RUN+=(--env FIX_GOOGLE_JAVA_FORMAT="true")
+  COMMAND_TO_RUN+=(--env FIX_GROOVY="true")
+  COMMAND_TO_RUN+=(--env FIX_JAVASCRIPT_ES="true")
+  COMMAND_TO_RUN+=(--env FIX_JAVASCRIPT_PRETTIER="true")
+  COMMAND_TO_RUN+=(--env FIX_JAVASCRIPT_STANDARD="true")
+  COMMAND_TO_RUN+=(--env FIX_JSON="true")
+  COMMAND_TO_RUN+=(--env FIX_JSONC="true")
+  COMMAND_TO_RUN+=(--env FIX_JSX="true")
+  COMMAND_TO_RUN+=(--env FIX_MARKDOWN="true")
+  COMMAND_TO_RUN+=(--env FIX_POWERSHELL="true")
+  COMMAND_TO_RUN+=(--env FIX_PROTOBUF="true")
+  COMMAND_TO_RUN+=(--env FIX_PYTHON_BLACK="true")
+  COMMAND_TO_RUN+=(--env FIX_PYTHON_ISORT="true")
+  COMMAND_TO_RUN+=(--env FIX_PYTHON_RUFF="true")
+  COMMAND_TO_RUN+=(--env FIX_RUBY="true")
+  COMMAND_TO_RUN+=(--env FIX_RUST_2015="true")
+  COMMAND_TO_RUN+=(--env FIX_RUST_2018="true")
+  COMMAND_TO_RUN+=(--env FIX_RUST_2021="true")
+  COMMAND_TO_RUN+=(--env FIX_RUST_CLIPPY="true")
+  COMMAND_TO_RUN+=(--env FIX_SCALAFMT="true")
+  COMMAND_TO_RUN+=(--env FIX_SHELL_SHFMT="true")
+  COMMAND_TO_RUN+=(--env FIX_SNAKEMAKE_SNAKEFMT="true")
+  COMMAND_TO_RUN+=(--env FIX_SQLFLUFF="true")
+  COMMAND_TO_RUN+=(--env FIX_TERRAFORM_FMT="true")
+  COMMAND_TO_RUN+=(--env FIX_TSX="true")
+  COMMAND_TO_RUN+=(--env FIX_TYPESCRIPT_ES="true")
+  COMMAND_TO_RUN+=(--env FIX_TYPESCRIPT_PRETTIER="true")
+  COMMAND_TO_RUN+=(--env FIX_TYPESCRIPT_STANDARD="true")
 }
 
 # Run the test setup function
@@ -316,3 +361,8 @@ for item in "${TEMP_ITEMS_TO_CLEAN[@]}"; do
     echo "${item} does not exist as expected"
   fi
 done
+
+if ! CheckUnexpectedGitChanges "$(pwd)"; then
+  echo "There are unexpected modifications to the working directory after running tests."
+  exit 1
+fi

--- a/test/testUtils.sh
+++ b/test/testUtils.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Default log level
+# shellcheck disable=SC2034
+LOG_LEVEL="DEBUG"
+
+# shellcheck source=/dev/null
+source "lib/functions/log.sh"
+
+function AssertArraysElementsContentMatch() {
+  local ARRAY_1_VARIABLE_NAME="${1}"
+  local ARRAY_2_VARIABLE_NAME="${2}"
+  local -n ARRAY_1="${ARRAY_1_VARIABLE_NAME}"
+  local -n ARRAY_2="${ARRAY_2_VARIABLE_NAME}"
+  if [[ "${ARRAY_1[*]}" == "${ARRAY_2[*]}" ]]; then
+    debug "${ARRAY_1_VARIABLE_NAME} (${ARRAY_1[*]}) matches the expected value: ${ARRAY_2[*]}"
+    RETURN_CODE=0
+  else
+    error "${ARRAY_1_VARIABLE_NAME} (${ARRAY_1[*]}) doesn't match the expected value: ${ARRAY_2[*]}"
+    RETURN_CODE=1
+  fi
+  unset -n ARRAY_1
+  unset -n ARRAY_2
+  return ${RETURN_CODE}
+}
+
+function CheckUnexpectedGitChanges() {
+  local GIT_REPOSITORY_PATH="${1}"
+  # Check if there are unexpected changes in the working directory:
+  # - Unstaged changes
+  # - Changes that are staged but not committed
+  # - Untracked files and directories
+  if ! git -C "${GIT_REPOSITORY_PATH}" diff --exit-code --quiet ||
+    ! git -C "${GIT_REPOSITORY_PATH}" diff --cached --exit-code --quiet ||
+    ! git -C "${GIT_REPOSITORY_PATH}" ls-files --others --exclude-standard --directory; then
+    echo "There are unexpected changes in the working directory of the ${GIT_REPOSITORY_PATH} Git repository."
+    git -C "${GIT_REPOSITORY_PATH}" status
+    return 1
+  fi
+}


### PR DESCRIPTION
# Proposed changes

Certain linters and formatters support fixing linting and formatting issues (fix mode). Before this change, Super-linter runs linters and formatters in a mode that doesn't modify the source code in any way (check only mode).

With this change, Super-linter supports running linters and formatters in fix mode if explicitly requested by the configuration. If the configuration includes a variable named FIX_<language_name>, Super-linters modifies the command to run the linter or formatter for <language_name> to enable fix mode.

The modifications to the linter or formatter command that Super-linter applies depend on what is the default for a particular linter: it either removes or adds options to the command to run the linter or formatter.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches with the version that release-please proposes.
