### PR TITLE
chore: mount the whole lib dir in the devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,13 +24,8 @@
       "type": "bind"
     },
     {
-      "source": "${localWorkspaceFolder}/lib/linter.sh",
-      "target": "/action/lib/linter.sh",
-      "type": "bind"
-    },
-    {
-      "source": "${localWorkspaceFolder}/lib/functions",
-      "target": "/action/lib/functions",
+      "source": "${localWorkspaceFolder}/lib",
+      "target": "/action/lib",
       "type": "bind"
     }
   ],


### PR DESCRIPTION
# Proposed changes

Bind-mount the whole `lib` directory as `/action/lib` in the devcontainer so we don't have to manually add `lib` subdirectories to the devcontainer configuration as we create them.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [ ] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches with the version that release-please proposes.
