### PR TITLE
chore: remove h1 from the pr template

### DIFF
--- a/.github/pull_request-template.md
+++ b/.github/pull_request-template.md
@@ -1,7 +1,6 @@
-# Proposed changes
-
-_describe the proposed changes and remove this template text_
-
+<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
+<!-- so contributors don't have to manually cut-paste the description after the H1. -->
+<!-- markdownlint-disable-next-line MD041 -->
 ## Readiness checklist
 
 In order to have this pull request merged, complete the following tasks.
@@ -21,4 +20,5 @@ In order to have this pull request merged, complete the following tasks.
 
 - [ ] Label as `breaking` if this change breaks compatibility with the previous released version.
 - [ ] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
-- [ ] Add the pull request to a milestone, eventually creating one, that matches with the version that release-please proposes.
+- [ ] Add the pull request to a milestone, eventually creating one, that matches
+  with the version that release-please proposes in the `preview-release-notes` CI job.


### PR DESCRIPTION
# Proposed changes

Remove the H1 heading from the PR template because GitHub automatically add the commit description before emitting the PR template, so contributors don't have to manually cut-paste the commit description after the H1 heading.

## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches with the version that release-please proposes.
