### PR TITLE
fix: add RENOVATE_X_IGNORE_RE2 env var to remove warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -413,6 +413,10 @@ ENV PATH="${PATH}:/node_modules/.bin"
 ENV PATH="${PATH}:/usr/lib/go/bin"
 ENV PATH="${PATH}:${DART_SDK}/bin:/root/.pub-cache/bin"
 
+# Renovate optionally requires re2, and will warn if its not present
+# Setting this envoronment variable disables this warning.
+ENV RENOVATE_X_IGNORE_RE2="true"
+
 # File to store linter versions
 ENV VERSION_FILE="/action/linterVersions.txt"
 RUN mkdir /action

--- a/test/inspec/super-linter/controls/super_linter.rb
+++ b/test/inspec/super-linter/controls/super_linter.rb
@@ -21,7 +21,7 @@ control "super-linter-environment-variables" do
   describe os_env("RENOVATE_X_IGNORE_RE2") do
     its("content") { should eq "true" }
   end
-  
+
   if (image == "standard")
     describe os_env("POWERSHELL_TELEMETRY_OPTOUT") do
       its("content") { should eq "1" }

--- a/test/inspec/super-linter/controls/super_linter.rb
+++ b/test/inspec/super-linter/controls/super_linter.rb
@@ -18,9 +18,13 @@ control "super-linter-environment-variables" do
     its("content") { should match(/^(standard|slim)$/) }
   end
 
+  describe os_env("RENOVATE_X_IGNORE_RE2") do
+    its("content") { should match(/^(standard|slim)$/) }
+  end
+  
   if (image == "standard")
     describe os_env("POWERSHELL_TELEMETRY_OPTOUT") do
-      its("content") { should eq "1" }
+      its("content") { should eq "true" }
     end
   end
 end

--- a/test/inspec/super-linter/controls/super_linter.rb
+++ b/test/inspec/super-linter/controls/super_linter.rb
@@ -24,7 +24,7 @@ control "super-linter-environment-variables" do
   
   if (image == "standard")
     describe os_env("POWERSHELL_TELEMETRY_OPTOUT") do
-      its("content") { should eq "true" }
+      its("content") { should eq "1" }
     end
   end
 end

--- a/test/inspec/super-linter/controls/super_linter.rb
+++ b/test/inspec/super-linter/controls/super_linter.rb
@@ -19,7 +19,7 @@ control "super-linter-environment-variables" do
   end
 
   describe os_env("RENOVATE_X_IGNORE_RE2") do
-    its("content") { should match(/^(standard|slim)$/) }
+    its("content") { should eq "true" }
   end
   
   if (image == "standard")


### PR DESCRIPTION
Renovate has an optional requirement for the RE2 package, and will warn if it is not present.

Setting env variable RENOVATE_X_IGNORE_RE2=true will hide this warning.

(see https://github.com/renovatebot/renovate/pull/21391)

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
  with the version that release-please proposes in the `preview-release-notes` CI job.
