### PR TITLE
chore: remove test leftovers before running fix test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,70 @@ on:
 permissions: {}
 
 jobs:
+  # Set build metadata before running any other job so we can reuse them for
+  # both the standandard and the slim images, and for verification as well.
+  # We can't run this as part of the build-container-image job because it
+  # runs multiple times due to its matrix configuration, leading to race
+  # conditions when verifying container image labels.
+  set-build-metadata:
+    name: Set build metadata
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      CONTAINER_IMAGE_BUILD_DATE: ${{ steps.set-container-image-build-metadata.outputs.CONTAINER_IMAGE_BUILD_DATE }}
+      CONTAINER_IMAGE_BUILD_REVISION: ${{ steps.set-container-image-build-metadata.outputs.CONTAINER_IMAGE_BUILD_REVISION }}
+      CONTAINER_IMAGE_BUILD_VERSION: ${{ steps.set-container-image-build-metadata.outputs.CONTAINER_IMAGE_BUILD_VERSION }}
+    steps:
+      - name: Set build metadata
+        id: set-container-image-build-metadata
+        run: |
+          if [[ ${{ github.event_name }} == 'push' ]] || [[ ${{ github.event_name }} == 'merge_group' ]]; then
+            BUILD_REVISION=${{ github.sha }}
+            BUILD_VERSION=${{ github.sha }}
+          elif [[ ${{ github.event_name }} == 'pull_request' ]]; then
+            BUILD_REVISION=${{ github.event.pull_request.head.sha }}
+            BUILD_VERSION=${{ github.event.pull_request.head.sha }}
+          else
+            echo "[ERROR] Event not supported when setting build revision and build version"
+            exit 1
+          fi
+
+          if [ -z "${BUILD_REVISION}" ]; then
+            echo "[ERROR] BUILD_REVISION is empty"
+            exit 1
+          fi
+
+          if [ -z "${BUILD_VERSION}" ]; then
+            echo "[ERROR] BUILD_VERSION is empty"
+            exit 1
+          fi
+
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+          echo "Build date: ${BUILD_DATE}"
+          echo "Build revision: ${BUILD_REVISION}"
+          echo "Build version: ${BUILD_VERSION}"
+
+          {
+            echo "BUILD_DATE=${BUILD_DATE}"
+            echo "BUILD_REVISION=${BUILD_REVISION}"
+            echo "BUILD_VERSION=${BUILD_VERSION}"
+          } >> "${GITHUB_ENV}"
+
+          {
+            echo "CONTAINER_IMAGE_BUILD_DATE=${BUILD_DATE}"
+            echo "CONTAINER_IMAGE_BUILD_REVISION=${BUILD_REVISION}"
+            echo "CONTAINER_IMAGE_BUILD_VERSION=${BUILD_VERSION}"
+          } >> "${GITHUB_OUTPUT}"
+
   build-container-image:
     name: Build and Test
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    needs:
+      - set-build-metadata
     concurrency:
       # Ref: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
       # github.head_ref: head_ref or source branch of the pull request
@@ -40,35 +99,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set build metadata
-        run: |
-          if [[ ${{ github.event_name }} == 'push' ]] || [[ ${{ github.event_name }} == 'merge_group' ]]; then
-            BUILD_REVISION=${{ github.sha }}
-            BUILD_VERSION=${{ github.sha }}
-          elif [[ ${{ github.event_name }} == 'pull_request' ]]; then
-            BUILD_REVISION=${{ github.event.pull_request.head.sha }}
-            BUILD_VERSION=${{ github.event.pull_request.head.sha }}
-          else
-            echo "[ERROR] Event not supported when setting build revision and build version"
-            exit 1
-          fi
-
-          if [ -z "${BUILD_REVISION}" ]; then
-            echo "[ERROR] BUILD_REVISION is empty"
-            exit 1
-          fi
-
-          if [ -z "${BUILD_VERSION}" ]; then
-            echo "[ERROR] BUILD_VERSION is empty"
-            exit 1
-          fi
-
-          {
-            echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-            echo "BUILD_REVISION=${BUILD_REVISION}"
-            echo "BUILD_VERSION=${BUILD_VERSION}"
-          } >> "${GITHUB_ENV}"
-
       - name: Free Disk space
         shell: bash
         run: |
@@ -86,9 +116,9 @@ jobs:
           context: .
           file: ./Dockerfile
           build-args: |
-            BUILD_DATE=${{ env.BUILD_DATE }}
-            BUILD_REVISION=${{ env.BUILD_REVISION }}
-            BUILD_VERSION=${{ env.BUILD_VERSION }}
+            BUILD_DATE=${{ needs.set-build-metadata.outputs.CONTAINER_IMAGE_BUILD_DATE }}
+            BUILD_REVISION=${{ needs.set-build-metadata.outputs.CONTAINER_IMAGE_BUILD_REVISION }}
+            BUILD_VERSION=${{ needs.set-build-metadata.outputs.CONTAINER_IMAGE_BUILD_VERSION }}
           cache-from: type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache
           outputs: type=docker,dest=/tmp/${{ env.CONTAINER_IMAGE_OUTPUT_IMAGE_NAME }}.tar
           push: false
@@ -108,11 +138,6 @@ jobs:
       - name: Print environment info
         run: |
           make info
-
-      # Validate the container image labels here so we don't have to pass the expected
-      # label values to other build jobs
-      - name: Validate container image labels
-        run: make validate-container-image-labels
 
       - name: Upload ${{ env.CONTAINER_IMAGE_OUTPUT_IMAGE_NAME }} container image
         uses: actions/upload-artifact@v4.3.4
@@ -214,6 +239,7 @@ jobs:
     permissions:
       contents: read
     needs:
+      - set-build-metadata
       - build-container-image
       - build-test-suite-matrix
     strategy:
@@ -226,13 +252,17 @@ jobs:
           - container-image-id: super-linter-slim-latest
             prefix: slim-
             target: slim
-        exclude:
-          # Don't validate container image labels because we do that when building the image
-          - test-case: validate-container-image-labels
+        include:
+          # Also run the test target to check if running the whole test suite
+          # in the same execution environment prevents it from succeeding
+          - test-case: test
     env:
       CONTAINER_IMAGE_ID: "ghcr.io/super-linter/super-linter:${{ matrix.images.prefix }}latest"
       CONTAINER_IMAGE_TARGET: "${{ matrix.images.target }}"
       CONTAINER_IMAGE_OUTPUT_IMAGE_NAME: "super-linter-${{ matrix.images.prefix }}latest"
+      BUILD_DATE: ${{ needs.set-build-metadata.outputs.CONTAINER_IMAGE_BUILD_DATE }}
+      BUILD_REVISION: ${{ needs.set-build-metadata.outputs.CONTAINER_IMAGE_BUILD_REVISION }}
+      BUILD_VERSION: ${{ needs.set-build-metadata.outputs.CONTAINER_IMAGE_BUILD_VERSION }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/test/testUtils.sh
+++ b/test/testUtils.sh
@@ -123,3 +123,45 @@ IsLanguageInSlimImage() {
     return 0
   fi
 }
+
+RemoveTestLeftovers() {
+  local LEFTOVERS_TO_CLEAN=()
+  LEFTOVERS_TO_CLEAN+=("${SUPER_LINTER_WORKSPACE}/${LINTERS_TEST_CASE_DIRECTORY}/rust_clippy/bad/target")
+  LEFTOVERS_TO_CLEAN+=("${SUPER_LINTER_WORKSPACE}/${LINTERS_TEST_CASE_DIRECTORY}/rust_clippy/bad/Cargo.lock")
+  LEFTOVERS_TO_CLEAN+=("${SUPER_LINTER_WORKSPACE}/${LINTERS_TEST_CASE_DIRECTORY}/rust_clippy/good/target")
+  LEFTOVERS_TO_CLEAN+=("${SUPER_LINTER_WORKSPACE}/${LINTERS_TEST_CASE_DIRECTORY}/rust_clippy/good/Cargo.lock")
+  # Delete leftovers in pwd in case the workspace is not pwd
+  LEFTOVERS_TO_CLEAN+=("$(pwd)/${LINTERS_TEST_CASE_DIRECTORY}/rust_clippy/bad/target")
+  LEFTOVERS_TO_CLEAN+=("$(pwd)/${LINTERS_TEST_CASE_DIRECTORY}/rust_clippy/bad/Cargo.lock")
+  LEFTOVERS_TO_CLEAN+=("$(pwd)/${LINTERS_TEST_CASE_DIRECTORY}/rust_clippy/good/target")
+  LEFTOVERS_TO_CLEAN+=("$(pwd)/${LINTERS_TEST_CASE_DIRECTORY}/rust_clippy/good/Cargo.lock")
+
+  # These variables are defined after configuring test cases, so they might not
+  # have been initialized yet
+  if [[ -v LOG_FILE_PATH ]] &&
+    [[ -n "${LOG_FILE_PATH}" ]]; then
+    LEFTOVERS_TO_CLEAN+=("${LOG_FILE_PATH}")
+    LEFTOVERS_TO_CLEAN+=("$(pwd)/$(basename "${LOG_FILE_PATH}")")
+  fi
+
+  if [[ -v SUPER_LINTER_GITHUB_STEP_SUMMARY_FILE_PATH ]] &&
+    [[ -n "${SUPER_LINTER_GITHUB_STEP_SUMMARY_FILE_PATH}" ]]; then
+    LEFTOVERS_TO_CLEAN+=("${SUPER_LINTER_GITHUB_STEP_SUMMARY_FILE_PATH}")
+    LEFTOVERS_TO_CLEAN+=("$(pwd)/$(basename "${SUPER_LINTER_GITHUB_STEP_SUMMARY_FILE_PATH}")")
+  fi
+
+  if [[ -v SUPER_LINTER_MAIN_OUTPUT_PATH ]] &&
+    [[ -n "${SUPER_LINTER_MAIN_OUTPUT_PATH}" ]]; then
+    LEFTOVERS_TO_CLEAN+=("${SUPER_LINTER_MAIN_OUTPUT_PATH}")
+    LEFTOVERS_TO_CLEAN+=("$(pwd)/$(basename "${SUPER_LINTER_MAIN_OUTPUT_PATH}")")
+  fi
+
+  if [[ -v SUPER_LINTER_SUMMARY_FILE_PATH ]] &&
+    [[ -n "${SUPER_LINTER_SUMMARY_FILE_PATH}" ]]; then
+    LEFTOVERS_TO_CLEAN+=("${SUPER_LINTER_SUMMARY_FILE_PATH}")
+    LEFTOVERS_TO_CLEAN+=("$(pwd)/$(basename "${SUPER_LINTER_SUMMARY_FILE_PATH}")")
+  fi
+
+  debug "Cleaning eventual test leftovers: ${LEFTOVERS_TO_CLEAN[*]}"
+  sudo rm -rfv "${LEFTOVERS_TO_CLEAN[@]}"
+}


### PR DESCRIPTION
- Remove test leftovers before initializing the workspace against which fix mode tests run. This prevents ownership issues.
- Pass container image build metadata as outputs of the container image build job so we can include the validate-container-image-labels target as other test target when we build the test matrix.
- Manually include the 'test' target when building the test suite matrix so we run it as part of the test suite to ensure that tests don't pollute each other's working directory.

Fix #5994

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
  with the version that release-please proposes in the `preview-release-notes` CI job.
