### PR TITLE
build: fix build metadata

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,15 +34,15 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - name: Set build metadata
         run: |
           if [[ ${{ github.event_name }} == 'push' ]] || [[ ${{ github.event_name }} == 'merge_group' ]]; then
             BUILD_REVISION=${{ github.sha }}
-            BUILD_VERSION=${{ github.sha }}
           elif [[ ${{ github.event_name }} == 'pull_request' ]]; then
             BUILD_REVISION=${{ github.event.pull_request.head.sha }}
-            BUILD_VERSION=${{ github.event.pull_request.head.sha }}
           else
             echo "[ERROR] Event not supported when setting build revision and build version"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,16 +27,16 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - name: Set build metadata
         id: set-container-image-build-metadata
         run: |
           if [[ ${{ github.event_name }} == 'push' ]] || [[ ${{ github.event_name }} == 'merge_group' ]]; then
             BUILD_REVISION=${{ github.sha }}
-            BUILD_VERSION=${{ github.sha }}
           elif [[ ${{ github.event_name }} == 'pull_request' ]]; then
             BUILD_REVISION=${{ github.event.pull_request.head.sha }}
-            BUILD_VERSION=${{ github.event.pull_request.head.sha }}
           else
             echo "[ERROR] Event not supported when setting build revision and build version"
             exit 1

--- a/scripts/build-metadata.sh
+++ b/scripts/build-metadata.sh
@@ -9,7 +9,12 @@ GetBuildDate() {
 }
 
 GetBuildRevision() {
-  git rev-parse HEAD
+  if [[ -v BUILD_REVISION ]]; then
+    # BUILD_REVISION is already set, no need to compute it
+    echo "${BUILD_REVISION}"
+  else
+    git rev-parse HEAD
+  fi
 }
 
 GetBuildVersion() {
@@ -21,6 +26,8 @@ GetBuildVersion() {
   if git diff-tree --no-commit-id --name-only -r "${BUILD_REVISION}" | grep -q "${VERSION_FILE_PATH}"; then
     cat "${VERSION_FILE_PATH}"
   else
+    # Fallback on the build revision to avoid that a non-release container image
+    # has BUILD_VERSION set to a release string
     GetBuildRevision
   fi
 }


### PR DESCRIPTION
- Don't set BUILD_VERSION in CI/CD workflows otherwise the build-metadata script will always fall back to those values instead of computing new ones.
- When calculating BUILD_REVISION, check if BUILD_REVISION is set before falling back.

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
  with the version that release-please proposes in the `preview-release-notes` CI job.
