### PR TITLE
chore: remove file_array leftovers

### DIFF
--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -343,7 +343,6 @@ BuildFileArrays() {
     elif [ "${FILE_TYPE}" == "coffee" ]; then
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-COFFEESCRIPT"
     elif [ "${FILE_TYPE}" == "cs" ]; then
-      FILE_ARRAY_CSHARP+=("${FILE}")
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-CSHARP"
     elif [ "${FILE_TYPE}" == "css" ] || [ "${FILE_TYPE}" == "scss" ] ||
       [ "${FILE_TYPE}" == "sass" ]; then
@@ -413,7 +412,6 @@ BuildFileArrays() {
     elif [ "$FILE_TYPE" == "jsonc" ] || [ "$FILE_TYPE" == "json5" ]; then
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-JSONC"
     elif [ "${FILE_TYPE}" == "json" ]; then
-      FILE_ARRAY_JSON+=("${FILE}")
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-JSON"
       if DetectOpenAPIFile "${FILE}"; then
         echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-OPENAPI"

--- a/lib/functions/worker.sh
+++ b/lib/functions/worker.sh
@@ -37,6 +37,7 @@ function LintCodebase() {
   local -n FILE_ARRAY="FILE_ARRAY_${FILE_TYPE}"
   local FILE_ARRAY_LANGUAGE_PATH="${FILE_ARRAYS_DIRECTORY_PATH}/file-array-${FILE_TYPE}"
   if [[ -e "${FILE_ARRAY_LANGUAGE_PATH}" ]]; then
+    FILE_ARRAY=()
     while read -r FILE; do
       if [[ "${TEST_CASE_RUN}" == "true" ]]; then
         debug "Ensure that the list files to check for ${FILE_TYPE} doesn't include test cases for other languages"

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -180,15 +180,6 @@ source /action/lib/globals/linterRules.sh
 # shellcheck source=/dev/null
 source /action/lib/globals/languages.sh
 
-##########################
-# Array of changed files #
-##########################
-for LANGUAGE in "${LANGUAGE_ARRAY[@]}"; do
-  FILE_ARRAY_VARIABLE_NAME="FILE_ARRAY_${LANGUAGE}"
-  debug "Initializing ${FILE_ARRAY_VARIABLE_NAME}"
-  eval "${FILE_ARRAY_VARIABLE_NAME}=()"
-done
-
 Header() {
   if [[ "${SUPPRESS_POSSUM}" == "false" ]]; then
     info "$(/bin/bash /action/lib/functions/possum.sh)"


### PR DESCRIPTION
Remove the initialization of FILE_ARRAY_xxx variables because worker.sh dynamically initializes them already.

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
  with the version that release-please proposes in the `preview-release-notes` CI job.
