### PR TITLE
fix: remove intro text from stdout and stderr and always create stdout and stderr

### DIFF
--- a/lib/functions/worker.sh
+++ b/lib/functions/worker.sh
@@ -209,16 +209,12 @@ function LintCodebase() {
   fi
 
   if [ -n "${STDOUT_LINTER}" ]; then
-    local STDOUT_LINTER_LOG_MESSAGE
-    STDOUT_LINTER_LOG_MESSAGE="Command output for ${FILE_TYPE}:\n------\n${STDOUT_LINTER}\n------"
-    info "${STDOUT_LINTER_LOG_MESSAGE}"
+    info "Command output for ${FILE_TYPE}:\n------\n${STDOUT_LINTER}\n------"
 
-    if [ ${PARALLEL_COMMAND_RETURN_CODE} -ne 0 ]; then
-      local STDOUT_LINTER_FILE_PATH
-      STDOUT_LINTER_FILE_PATH="${SUPER_LINTER_PRIVATE_OUTPUT_DIRECTORY_PATH}/super-linter-parallel-stdout-${FILE_TYPE}"
-      debug "Saving stdout for ${FILE_TYPE} to ${STDOUT_LINTER_FILE_PATH} in case we need it later"
-      printf '%s\n' "${STDOUT_LINTER_LOG_MESSAGE}" >"${STDOUT_LINTER_FILE_PATH}"
-    fi
+    local STDOUT_LINTER_FILE_PATH
+    STDOUT_LINTER_FILE_PATH="${SUPER_LINTER_PRIVATE_OUTPUT_DIRECTORY_PATH}/super-linter-parallel-stdout-${FILE_TYPE}"
+    debug "Saving stdout for ${FILE_TYPE} to ${STDOUT_LINTER_FILE_PATH} in case we need it later"
+    printf '%s\n' "${STDOUT_LINTER}" >"${STDOUT_LINTER_FILE_PATH}"
   else
     debug "Stdout for ${FILE_TYPE} is empty"
   fi
@@ -229,15 +225,12 @@ function LintCodebase() {
   fi
 
   if [ -n "${STDERR_LINTER}" ]; then
-    local STDERR_LINTER_LOG_MESSAGE
-    STDERR_LINTER_LOG_MESSAGE="Stderr contents for ${FILE_TYPE}:\n------\n${STDERR_LINTER}\n------"
-    info "${STDERR_LINTER_LOG_MESSAGE}"
-    if [ ${PARALLEL_COMMAND_RETURN_CODE} -ne 0 ]; then
-      local STDERR_LINTER_FILE_PATH
-      STDERR_LINTER_FILE_PATH="${SUPER_LINTER_PRIVATE_OUTPUT_DIRECTORY_PATH}/super-linter-parallel-stderr-${FILE_TYPE}"
-      debug "Saving stderr for ${FILE_TYPE} to ${STDERR_LINTER_FILE_PATH} in case we need it later"
-      printf '%s\n' "${STDERR_LINTER_LOG_MESSAGE}" >"${STDERR_LINTER_FILE_PATH}"
-    fi
+    info "Stderr contents for ${FILE_TYPE}:\n------\n${STDERR_LINTER}\n------"
+
+    local STDERR_LINTER_FILE_PATH
+    STDERR_LINTER_FILE_PATH="${SUPER_LINTER_PRIVATE_OUTPUT_DIRECTORY_PATH}/super-linter-parallel-stderr-${FILE_TYPE}"
+    debug "Saving stderr for ${FILE_TYPE} to ${STDERR_LINTER_FILE_PATH} in case we need it later"
+    printf '%s\n' "${STDERR_LINTER}" >"${STDERR_LINTER_FILE_PATH}"
   else
     debug "Stderr for ${FILE_TYPE} is empty"
   fi

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -511,13 +511,13 @@ Footer() {
           WriteSummaryLineFailure "${SUPER_LINTER_SUMMARY_OUTPUT_PATH}" "${LANGUAGE}"
         fi
 
-        # Print output as error in case users disabled the INFO level so they
-        # get feedback
+        # Print stdout and stderr in case the log level is higher than INFO
+        # so users still get feedback. Print output as error so it gets emitted
         if [[ "${LOG_VERBOSE}" != "true" ]]; then
           local STDOUT_LINTER_FILE_PATH
           STDOUT_LINTER_FILE_PATH="${SUPER_LINTER_PRIVATE_OUTPUT_DIRECTORY_PATH}/super-linter-parallel-stdout-${LANGUAGE}"
           if [[ -e "${STDOUT_LINTER_FILE_PATH}" ]]; then
-            error "$(cat "${STDOUT_LINTER_FILE_PATH}")"
+            error "Stdout contents for ${LANGUAGE}:\n------\n$(cat "${STDOUT_LINTER_FILE_PATH}")\n------"
           else
             debug "Stdout output file path for ${LANGUAGE} (${STDOUT_LINTER_FILE_PATH}) doesn't exist"
           fi
@@ -525,7 +525,7 @@ Footer() {
           local STDERR_LINTER_FILE_PATH
           STDERR_LINTER_FILE_PATH="${SUPER_LINTER_PRIVATE_OUTPUT_DIRECTORY_PATH}/super-linter-parallel-stderr-${LANGUAGE}"
           if [[ -e "${STDERR_LINTER_FILE_PATH}" ]]; then
-            error "$(cat "${STDERR_LINTER_FILE_PATH}")"
+            error "Stderr contents for ${LANGUAGE}:\n------\n$(cat "${STDERR_LINTER_FILE_PATH}")\n------"
           else
             debug "Stderr output file path for ${LANGUAGE} (${STDERR_LINTER_FILE_PATH}) doesn't exist"
           fi


### PR DESCRIPTION
- Remove introductory text from stdout and stderr files.
- Always create stdout and stderr files, not only when there are errors.

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [ ] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
  with the version that release-please proposes in the `preview-release-notes` CI job.
