### PR TITLE
fix: avoid concurrent edits to the same file

### DIFF
--- a/lib/functions/validation.sh
+++ b/lib/functions/validation.sh
@@ -7,6 +7,7 @@ function ValidateBooleanConfigurationVariables() {
   ValidateBooleanVariable "DISABLE_ERRORS" "${DISABLE_ERRORS}"
   ValidateBooleanVariable "ENABLE_GITHUB_ACTIONS_GROUP_TITLE" "${ENABLE_GITHUB_ACTIONS_GROUP_TITLE}"
   ValidateBooleanVariable "ENABLE_GITHUB_ACTIONS_STEP_SUMMARY" "${ENABLE_GITHUB_ACTIONS_STEP_SUMMARY}"
+  ValidateBooleanVariable "FIX_MODE_ENABLED" "${FIX_MODE_ENABLED}"
   ValidateBooleanVariable "FIX_MODE_TEST_CASE_RUN" "${FIX_MODE_TEST_CASE_RUN}"
   ValidateBooleanVariable "IGNORE_GENERATED_FILES" "${IGNORE_GENERATED_FILES}"
   ValidateBooleanVariable "IGNORE_GITIGNORED_FILES" "${IGNORE_GITIGNORED_FILES}"
@@ -184,6 +185,21 @@ function ValidateCheckModeAndFixModeVariables() {
     unset -n FIX_MODE_REF
     unset -n VALIDATE_MODE_REF
   done
+}
+
+function CheckIfFixModeIsEnabled() {
+  for LANGUAGE in "${LANGUAGE_ARRAY[@]}"; do
+    local FIX_MODE_VARIABLE_NAME="FIX_${LANGUAGE}"
+    local -n FIX_MODE_REF="${FIX_MODE_VARIABLE_NAME}"
+
+    if [[ -v "${FIX_MODE_VARIABLE_NAME}" ]] &&
+      [[ "${FIX_MODE_REF:-"false"}" == "true" ]]; then
+      FIX_MODE_ENABLED="true"
+      debug "Fix mode for ${LANGUAGE} is ${FIX_MODE_REF}. Set FIX_MODE_ENABLED to ${FIX_MODE_ENABLED}"
+    fi
+    unset -n FIX_MODE_REF
+  done
+  ValidateBooleanVariable "FIX_MODE_ENABLED" "${FIX_MODE_ENABLED}"
 }
 
 function CheckIfGitBranchExists() {

--- a/test/lib/validationTest.sh
+++ b/test/lib/validationTest.sh
@@ -499,6 +499,32 @@ function ValidateCheckModeAndFixModeVariablesTest() {
   notice "${FUNCTION_NAME} PASS"
 }
 
+CheckIfFixModeIsEnabledTest() {
+  # shellcheck disable=SC2034
+  LANGUAGE_ARRAY=('A')
+
+  FIX_MODE_ENABLED="false"
+  FIX_A="true"
+  CheckIfFixModeIsEnabled
+  EXPECTED_FIX_MODE_ENABLED="true"
+  if [[ "${FIX_MODE_ENABLED}" == "${EXPECTED_FIX_MODE_ENABLED}" ]]; then
+    debug "FIX_MODE_ENABLED variable has the expected value: ${FIX_MODE_ENABLED}"
+  else
+    fatal "FIX_MODE_ENABLED (${FIX_MODE_ENABLED}) doesn't match with the expected value: ${EXPECTED_FIX_MODE_ENABLED}"
+  fi
+
+  FIX_MODE_ENABLED="false"
+  FIX_A="false"
+  CheckIfFixModeIsEnabled
+  EXPECTED_FIX_MODE_ENABLED="false"
+  if [[ "${FIX_MODE_ENABLED}" == "${EXPECTED_FIX_MODE_ENABLED}" ]]; then
+    debug "FIX_MODE_ENABLED variable has the expected value: ${FIX_MODE_ENABLED}"
+  else
+    fatal "FIX_MODE_ENABLED (${FIX_MODE_ENABLED}) doesn't match with the expected value: ${EXPECTED_FIX_MODE_ENABLED}"
+  fi
+
+}
+
 IsUnsignedIntegerSuccessTest
 IsUnsignedIntegerFailureTest
 ValidateDeprecatedVariablesTest
@@ -509,3 +535,4 @@ ValidateAnsibleDirectoryTest
 ValidateValidationVariablesTest
 ValidationVariablesExportTest
 ValidateCheckModeAndFixModeVariablesTest
+CheckIfFixModeIsEnabledTest


### PR DESCRIPTION
Reduce the number of processes to 1 if at least one FIX_xxxx variable is set to true. This avoids that Parallel runs multiple processes that might edit the same file at the same time.

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue,
  I added the `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
  with the version that release-please proposes in the `preview-release-notes` CI job.
