### PR TITLE
chore: shorten linter versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,7 +342,7 @@ lint-subset-files-enable-expensive-io-checks: ## Lint a small subset of files in
 		$(SUPER_LINTER_TEST_CONTAINER_URL)
 
 .PHONY: test-lib
-test-lib: test-globals-languages test-linter-rules test-build-file-list test-detect-files test-github-event test-setup-ssh test-validation test-output test-linter-commands ## Test super-linter libs and globals
+test-lib: test-globals-languages test-linter-rules test-build-file-list test-detect-files test-github-event test-setup-ssh test-validation test-output test-linter-commands test-linter-versions ## Test super-linter libs and globals
 
 .PHONY: test-globals-languages
 test-globals-languages: ## Test globals/languages.sh
@@ -432,6 +432,15 @@ test-linter-commands: ## Test linterCommands
 		-v "$(CURDIR):/tmp/lint" \
 		-w /tmp/lint \
 		--entrypoint /tmp/lint/test/lib/linterCommandsTest.sh \
+		--rm \
+		$(SUPER_LINTER_TEST_CONTAINER_URL)
+
+.PHONY: test-linter-versions
+test-linter-versions: ## Test linterVersions
+	docker run \
+		-v "$(CURDIR):/tmp/lint" \
+		-w /tmp/lint \
+		--entrypoint /tmp/lint/test/lib/linterVersionsTest.sh \
 		--rm \
 		$(SUPER_LINTER_TEST_CONTAINER_URL)
 

--- a/lib/linter.sh
+++ b/lib/linter.sh
@@ -686,7 +686,7 @@ Header
 UpdateLoopsForImage
 
 # Print linter versions
-info "$(cat "${VERSION_FILE}")"
+info "This version of Super-linter includes the following tools:\n$(cat "${VERSION_FILE}")"
 
 #######################
 # Get GitHub Env Vars #

--- a/test/lib/linterVersionsTest.sh
+++ b/test/lib/linterVersionsTest.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# shellcheck source=/dev/null
+source "test/testUtils.sh"
+
+echo -e "Versions file (${VERSION_FILE}) contents:\n$(cat "${VERSION_FILE}")"
+
+VersionsFileSortTest() {
+  local FUNCTION_NAME
+  FUNCTION_NAME="${FUNCNAME[0]}"
+  info "${FUNCTION_NAME} start"
+
+  if ! sort --check "${VERSION_FILE}"; then
+    fatal "Linters version file (${VERSION_FILE}) is not sorted"
+  fi
+
+  notice "${FUNCTION_NAME} PASS"
+}
+
+VersionsFileCompletenessTest() {
+  local FUNCTION_NAME
+  FUNCTION_NAME="${FUNCNAME[0]}"
+  info "${FUNCTION_NAME} start"
+
+  local LINTERS_VERSION_FILE_LINES_COUNT
+  LINTERS_VERSION_FILE_LINES_COUNT=$(wc --lines "${VERSION_FILE}" | awk '{print $1}')
+  debug "Linters version file lines count: ${LINTERS_VERSION_FILE_LINES_COUNT}"
+
+  local EXPECTED_LANGUAGE_COUNT=${#LANGUAGE_ARRAY[@]}
+
+  if ! IsStandardImage; then
+    EXPECTED_LANGUAGE_COUNT=$((EXPECTED_LANGUAGE_COUNT - ${#LANGUAGES_NOT_IN_SLIM_IMAGE[@]}))
+  fi
+
+  if [[ ${LINTERS_VERSION_FILE_LINES_COUNT} -ne ${EXPECTED_LANGUAGE_COUNT} ]]; then
+    fatal "Linters version file lines count (${LINTERS_VERSION_FILE_LINES_COUNT}) doesn't match the length of the languages array (${EXPECTED_LANGUAGE_COUNT}). Is a version descriptor missing in the versions file? Is the version descriptor spanning multiple lines?"
+  else
+    debug "The versions file lines count (${LINTERS_VERSION_FILE_LINES_COUNT}) matches the expected value (${EXPECTED_LANGUAGE_COUNT})"
+  fi
+
+  for LANGUAGE in "${LANGUAGE_ARRAY[@]}"; do
+    if ! IsStandardImage && ! IsLanguageInSlimImage "${LANGUAGE}"; then
+      debug "Skip checking if ${LANGUAGE} is in the versions file because ${LANGUAGE} is not included in the slim image"
+      continue
+    fi
+
+    if ! grep -q "${LANGUAGE}" "${VERSION_FILE}"; then
+      fatal "${LANGUAGE} is absent from the versions file"
+    else
+      debug "${LANGUAGE} present in the versions file"
+    fi
+  done
+
+  notice "${FUNCTION_NAME} PASS"
+}
+
+VersionsFileSortTest
+VersionsFileCompletenessTest


### PR DESCRIPTION
Shorten the linter versions file by keeping only the version string for each linter, instead of the entire output of the version command

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
