### PR TITLE
chore: Add `.DS_Store` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ super-linter-output/
 custom-super-linter-output-directory-name/
 super-linter-github-actions-step-summary-output*
 github-step-summary.md
+
+# MacOS File
+.DS_Store


### PR DESCRIPTION
<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [X] I checked that all workflows return a success.
- [X] I included all the needed documentation for this change.
- [X] I provided the necessary tests.
- [X] I squashed all the commits into a single commit.
- [X] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [X] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
