### PR TITLE
chore: explain how to configure the path

### DIFF
--- a/docs/add-new-linter.md
+++ b/docs/add-new-linter.md
@@ -34,8 +34,18 @@ new tool needs in the `PATH`, and the expected version command:
 
 - Install the tool by pointing to specific package or container image versions:
 
-  - If there are PyPi packages, create a text file named
-    `dependencies/python/<name-of-tool>.txt` and list the packages there.
+  - If there are PyPi packages:
+
+    1. Create a text file named `dependencies/python/<name-of-tool>.txt` and
+       list the packages there.
+    1. Add the new virtual environment `bin` directory to the `PATH` in the
+       Super-linter `Dockerfile`, in the `Configure Environment` section.
+       Example:
+
+       ```dockerfile
+       ENV PATH="${PATH}:/venvs/<name-of-tool>/bin"
+       ```
+
   - If there are npm packages, update `dependencies/package.json` and
     `dependencies/package-lock.json`. by adding the new packages.
   - If there are Ruby Gems, update `dependencies/Gemfile` and


### PR DESCRIPTION
Explain how to configure the PATH when installing new tools using pip.

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
