### PR TITLE
chore: group dependency updates prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,14 +16,56 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 100
+    groups:
+      dev-ci-tools:
+        applies-to: version-updates
+        patterns:
+          - actions/*
+          - akhilerm/tag-push-action
+          - docker/*
+          - googleapis/*
+          - peter-evans/create-issue-from-file
 
   - package-ecosystem: "npm"
     commit-message:
       prefix: "deps(npm)"
-    directory: "/dependencies"
+    directories:
+      - /dependencies
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 100
+    groups:
+      eslint-plugins-configs:
+        applies-to: version-updates
+        patterns:
+          - "eslint-config*"
+          - "eslint-plugin*"
+      next:
+        applies-to: version-updates
+        patterns:
+          - next
+          - next-pwa
+      react:
+        applies-to: version-updates
+        patterns:
+          - "react*"
+          - "@babel/preset-react"
+          - "@react-native/eslint-config"
+      stylelint:
+        applies-to: version-updates
+        patterns:
+          - "stylelint*"
+      textlint:
+        applies-to: version-updates
+        patterns:
+          - "textlint*"
+      typescript:
+        applies-to: version-updates
+        patterns:
+          - "@babel/preset-typescript"
+          - "@typescript-eslint/eslint-plugin"
+          - ts-standard
+          - typescript
 
   - package-ecosystem: "bundler"
     commit-message:
@@ -32,6 +74,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 100
+    groups:
+      rubocop:
+        applies-to: version-updates
+        patterns:
+          - "rubocop*"
 
   - package-ecosystem: "docker"
     commit-message:
@@ -40,38 +87,86 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 100
+    groups:
+      docker:
+        applies-to: version-updates
+        # We can group all Docker dependencies because they are isolated from
+        # each other
+        patterns:
+          - alpine/helm
+          - alpine/terragrunt
+          - dotenvlinter/dotenv-linter
+          - dotnet/sdk
+          - golang
+          - golangci/golangci-lint
+          - goreleaser/goreleaser
+          - hadolint/hadolint
+          - hashicorp/terraform
+          - kustomize/kustomize
+          - tenable/terrascan
+          - terraform-linters/tflint
+          - yannh/kubeconform
+          - koalaman/shellcheck
+          - mstruebing/editorconfig-checker
+          - mvdan/shfmt
+          - rhysd/actionlint
+          - scalameta/scalafmt
+          - zricethezav/gitleaks
+          - yoheimuta/protolint
+          - clj-kondo/clj-kondo
+          - dart
+          - powershell
+          - composer/composer
+          - python
 
   - package-ecosystem: "pip"
     commit-message:
       prefix: "deps(python)"
-    directory: "/dependencies/python/"
+    directories:
+      - /dependencies/python/
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 100
+    groups:
+      pip:
+        applies-to: version-updates
+        # We can group all python dependencies because each uses its own
+        # virtual environments
+        patterns:
+          - ansible-lint
+          - black
+          - cfn-lint
+          - checkov
+          - cpplint
+          - flake8
+          - isort
+          - pyink
+          - pylint
+          - ruff
+          - snakefmt
+          - snakemake
+          - sqlfluff
+          - yamllint
 
   - package-ecosystem: "gradle"
     commit-message:
       prefix: "deps(java)"
-    directory: "/dependencies/checkstyle"
+    directories:
+      - "/dependencies/checkstyle"
+      - "/dependencies/google-java-format"
+      - "/dependencies/ktlint"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 100
-
-  - package-ecosystem: "gradle"
-    commit-message:
-      prefix: "deps(java)"
-    directory: "/dependencies/google-java-format"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 100
-
-  - package-ecosystem: "gradle"
-    commit-message:
-      prefix: "deps(java)"
-    directory: "/dependencies/ktlint"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 100
+    groups:
+      java-gradle:
+        applies-to: version-updates
+        # We can group all Java dependencies because they are isolated from
+        # each other
+        patterns:
+          - "com.google.googlejavaformat:google-java-format"
+          - "com.pinterest.ktlint:ktlint-cli"
+          - "com.puppycrawl.tools:checkstyle"
 
   - package-ecosystem: "docker"
     commit-message:
@@ -84,7 +179,8 @@ updates:
   - package-ecosystem: "npm"
     commit-message:
       prefix: "ci(dev-npm)"
-    directory: "/dev-dependencies"
+    directories:
+      - /dev-dependencies
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 100
@@ -97,3 +193,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 100
+    groups:
+      composer:
+        applies-to: version-updates
+        patterns:
+          - squizlabs/php_codesniffer
+          - phpstan/phpstan
+          - vimeo/psalm

--- a/dependencies/composer/composer.json
+++ b/dependencies/composer/composer.json
@@ -3,6 +3,7 @@
   "require": {
     "squizlabs/php_codesniffer": "^3.10.1",
     "phpstan/phpstan": "^1.11.2",
-    "vimeo/psalm": "^5.24.0"
+    "vimeo/psalm": "^5.24.0",
+    "php": "^8.3"
   }
 }

--- a/dependencies/composer/composer.lock
+++ b/dependencies/composer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b4539dab73f09cdc845962c74e8fc33",
+    "content-hash": "83c178db3f6e7f578d7120a28f2453ec",
     "packages": [
         {
             "name": "amphp/amp",
@@ -2232,7 +2232,9 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": "^8.3"
+    },
     "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/docs/add-new-linter.md
+++ b/docs/add-new-linter.md
@@ -46,6 +46,9 @@ new tool needs in the `PATH`, and the expected version command:
        ENV PATH="${PATH}:/venvs/<name-of-tool>/bin"
        ```
 
+    1. Add the new dependencies to the `pip` group in the DependaBot
+       configuration file (`.github/dependabot.yaml`).
+
   - If there are npm packages, update `dependencies/package.json` and
     `dependencies/package-lock.json`. by adding the new packages.
   - If there are Ruby Gems, update `dependencies/Gemfile` and
@@ -73,6 +76,7 @@ new tool needs in the `PATH`, and the expected version command:
 
     3. Update the `dependencies` section in
        `dependencies/<name-of-tool>/build.gradle` to install your dependencies.
+
     4. Add the following content to the `Dockerfile`:
 
        ```dockerfile
@@ -91,15 +95,9 @@ new tool needs in the `PATH`, and the expected version command:
        )"
        ```
 
-    6. Add the new to DependaBot configuration:
-
-       ```yaml
-       - package-ecosystem: "gradle"
-         directory: "/dependencies/<name-of-tool>"
-         schedule:
-           interval: "weekly"
-         open-pull-requests-limit: 10
-       ```
+    6. Add the new tool dependencies to the DependaBot configuration in the
+       `directories` list and in the `java-gradle` group of the `gradle` package
+       ecosystem.
 
   - If there is a container (Docker) image:
 
@@ -115,6 +113,9 @@ new tool needs in the `PATH`, and the expected version command:
        ```sh
        COPY --from=<name-of-tool> /usr/local/bin/<name-of-command> /usr/bin/
        ```
+
+    1. Add the new dependency to the `docker` group in the DependaBot
+       configuration file.
 
 ## Run the new tool
 


### PR DESCRIPTION
Group dependency update PRs in order to minimize the number of PRs to review.

Specify a PHP version in the Composer file to unblock PHP updates.

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [ ] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [ ] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [ ] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [ ] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
