### PR TITLE
chore: move npm audit to a dedicated task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,14 @@ jobs:
       - set-build-metadata
       - build-container-image
       - build-test-suite-matrix
+    # Don't fail the entire test suite when:
+    # - Running npm audit, so we can see test results even if there are
+    #   vulnerable dependencies that might be unrelated to the PR
+    # - Running the 'test' target because it runs all the tests, including the
+    #   ones that are allowed to fail
+    continue-on-error: ${{ matrix.test-case == 'npm-audit' || matrix.test-case == 'test' }}
     strategy:
+      fail-fast: true
       matrix:
         test-case: ${{ fromJson(needs.build-test-suite-matrix.outputs.matrix) }}
         images:

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,6 @@ RUN apk add --no-cache \
 COPY dependencies/package.json dependencies/package-lock.json /
 RUN apk add --no-cache --virtual .node-build-deps \
   npm \
-  && npm audit \
   && npm install --strict-peer-deps \
   && npm cache clean --force \
   && chown -R "$(id -u)":"$(id -g)" node_modules \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 all: info docker test ## Run all targets.
 
 .PHONY: test
-test: info validate-container-image-labels docker-build-check docker-dev-container-build-check test-lib inspec lint-codebase fix-codebase test-default-config-files test-actions-runner-debug test-actions-steps-debug test-runner-debug test-find lint-subset-files test-custom-ssl-cert test-non-default-workdir test-git-flags test-non-default-home-directory test-git-initial-commit test-git-merge-commit-push test-log-level test-use-find-and-ignore-gitignored-files test-linters-expect-failure-log-level-notice test-bash-exec-library-expect-success test-bash-exec-library-expect-failure test-save-super-linter-output test-save-super-linter-output-custom-path test-save-super-linter-custom-summary test-custom-gitleaks-log-level test-dont-save-super-linter-log-file test-dont-save-super-linter-output test-linters test-linters-fix-mode ## Run the test suite
+test: info validate-container-image-labels docker-build-check docker-dev-container-build-check npm-audit test-lib inspec lint-codebase fix-codebase test-default-config-files test-actions-runner-debug test-actions-steps-debug test-runner-debug test-find lint-subset-files test-custom-ssl-cert test-non-default-workdir test-git-flags test-non-default-home-directory test-git-initial-commit test-git-merge-commit-push test-log-level test-use-find-and-ignore-gitignored-files test-linters-expect-failure-log-level-notice test-bash-exec-library-expect-success test-bash-exec-library-expect-failure test-save-super-linter-output test-save-super-linter-output-custom-path test-save-super-linter-custom-summary test-custom-gitleaks-log-level test-dont-save-super-linter-log-file test-dont-save-super-linter-output test-linters test-linters-fix-mode ## Run the test suite
 
 # if this session isn't interactive, then we don't want to allocate a
 # TTY, which would fail, but if it is interactive, we do want to attach
@@ -164,6 +164,17 @@ validate-container-image-labels: ## Validate container image labels
 		$(BUILD_DATE) \
 		$(BUILD_REVISION) \
 		$(BUILD_VERSION)
+
+.PHONY: npm-audit
+npm-audit: ## Run npm audit to check for known vulnerable dependencies
+	docker run $(DOCKER_FLAGS) \
+		--entrypoint /bin/bash \
+		--rm \
+		-v "$(CURDIR)/dependencies/package-lock.json":/package-lock.json \
+		-v "$(CURDIR)/dependencies/package.json":/package.json \
+		--workdir / \
+		$(SUPER_LINTER_TEST_CONTAINER_URL) \
+		-c "npm audit"
 
 # For some cases, mount a directory that doesn't have too many files to keep tests short
 


### PR DESCRIPTION
Move 'npm audit' execution to a dedicated target (and corresponding step) so that we can modularize it, and avoid that it blocks that whole test suite.

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [ ] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
