### PR TITLE
chore: move base image to a dedicated group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -117,6 +117,12 @@ updates:
           - dart
           - powershell
           - composer/composer
+      docker-base-images:
+        applies-to: version-updates
+        patterns:
+          # Move the base image to a dedicated group to avoid blocking other
+          # dependencies in the case of wheel not being available for more
+          # recent Python version
           - python
 
   - package-ecosystem: "pip"


### PR DESCRIPTION
Move the python base image to a dedicated dependency group because some Python wheels might not be available for newer Python versions yet. This will avoid blocking python dependency updates waiting for wheels to be rebuilt for a given python version.

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [ ] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
