### PR TITLE
fix: downgrade npm-groovy-lint to 15.0.0

### DIFF
--- a/dependencies/package-lock.json
+++ b/dependencies/package-lock.json
@@ -34,7 +34,7 @@
         "markdownlint-cli": "^0.42.0",
         "next": "^15.0.3",
         "next-pwa": "^5.6.0",
-        "npm-groovy-lint": "^15.0.2",
+        "npm-groovy-lint": "^15.0.0",
         "postcss-less": "^6.0.0",
         "prettier": "^3.3.3",
         "prettyjson": "^1.2.5",
@@ -17287,9 +17287,10 @@
       }
     },
     "node_modules/npm-groovy-lint": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-15.0.2.tgz",
-      "integrity": "sha512-1HvEdy0eKIHOx/TIBgehQGEA+UObCUFsmHJ45LRxCkiMUTMMYEDXlTPV6u78UMNCsFqcGzeMUPfi4tXAxss2Tg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/npm-groovy-lint/-/npm-groovy-lint-15.0.0.tgz",
+      "integrity": "sha512-MSVHrSK2bVQnQUSIiyXp8Am33E6gt3QUBXm8Z+AA4dToLqpU0+46VCiIcOCTSiKmz9Rd7DoGgFrd5eBEO4qBsg==",
+      "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "axios": "^1.6.2",
@@ -17302,7 +17303,7 @@
         "fs-extra": "^11.0.0",
         "glob": "^11.0.0",
         "import-fresh": "^3.2.1",
-        "java-caller": "^4.1.1",
+        "java-caller": "^4.0.0",
         "js-yaml": "^4.1.0",
         "node-sarif-builder": "^3.0.0",
         "optionator": "^0.9.0",

--- a/dependencies/package.json
+++ b/dependencies/package.json
@@ -29,7 +29,7 @@
     "markdownlint-cli": "^0.42.0",
     "next": "^15.0.3",
     "next-pwa": "^5.6.0",
-    "npm-groovy-lint": "^15.0.2",
+    "npm-groovy-lint": "^15.0.0",
     "postcss-less": "^6.0.0",
     "prettier": "^3.3.3",
     "prettyjson": "^1.2.5",

--- a/test/linters/groovy/groovy_good_02.groovy
+++ b/test/linters/groovy/groovy_good_02.groovy
@@ -1,0 +1,12 @@
+import groovy.text.*
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
+
+@Library('somelib')
+import com.mycorp.pipeline.somelib.Helper
+
+int useSomeLib(Helper helper) {
+    helper.prepare()
+    return helper.count()
+}
+
+echo useSomeLib(new Helper('some text'))


### PR DESCRIPTION
Fix #6371

npm-groovy-lint > 15.0.0 is impacted by:

- https://github.com/nvuillam/npm-groovy-lint/issues/428
- https://github.com/nvuillam/npm-groovy-lint/issues/422

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [ ] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [ x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
