### PR TITLE
fix: make git conflict markers check more precise

### DIFF
--- a/scripts/git-merge-conflict-markers.sh
+++ b/scripts/git-merge-conflict-markers.sh
@@ -4,15 +4,27 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-GIT_MERGE_CONFLICT_EXPRESSION='^(<<<<<<<|=======|>>>>>>>)'
+GIT_MERGE_CONFLICT_START='^<{7} .+$'
+GIT_MERGE_CONFLICT_MIDST='^={7}$'
+GIT_MERGE_CONFLICT_END='^>{7} .+$'
 
 if [[ "$*" == "--version" ]]; then
   echo "1.0.0"
   exit 0
 fi
 
-if grep -l -E "${GIT_MERGE_CONFLICT_EXPRESSION}" "$@"; then
-  echo "Found Git merge conflict markers"
+declare -i errors=0
+
+for file in "$@"; do
+  if grep -q -E "${GIT_MERGE_CONFLICT_START}" "$file" &&
+    grep -q -E "${GIT_MERGE_CONFLICT_MIDST}" "$file" &&
+    grep -q -E "${GIT_MERGE_CONFLICT_END}" "$file"; then
+    echo "Found Git merge conflict markers: \"$file\""
+    errors=$((errors + 1))
+  fi
+done
+
+if [[ $errors -gt 0 ]]; then
   exit 1
 else
   echo "No merge conflicts found in $*"

--- a/test/linters/git_merge_conflict_markers/git_merge_conflict_markers_good_02.txt
+++ b/test/linters/git_merge_conflict_markers/git_merge_conflict_markers_good_02.txt
@@ -1,1 +1,24 @@
+<<<<<<<<<<<<<
 Hello world 2
+=============
+Goodbye 2
+>>>>>>>>>>>>>
+The "markers" above look like Git merge conflict markers,
+though they aren't. Please find correct conflict markers
+regexp at "/scripts/git-merge-conflict-markers.sh" file.
+
+- Each marker should consist of exactly seven same chars.
+- Opening marker is identified with '<' char.
+- Closing marker is identified with '>' char.
+- Divider marker is identified with '=' char.
+- Opening marker (our version of the conflicting change) and
+  closing marker (their version of the change) are followed
+  by one space and identifier of the base or HEAD branch and
+  identifier of the compared branch respectively.
+- The line with the marker that divides our changes from the
+  changes in the other branch consists of only divider char.
+
+Refs:
+- https://git-scm.com/docs/git-merge#_how_conflicts_are_presented
+- https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line#competing-line-change-merge-conflicts
+- https://stackoverflow.com/a/63638891/5093149


### PR DESCRIPTION
The https://github.com/super-linter/super-linter/pull/6113 introduced new Git
merge conflicts linter check, that is error prone in some conditions (see
screenshot).

This PR adjusts this check to be more precise and exact in a way that all three
markers should be found to identify check as failed. Additionally improve Git
merge conflict markers matchers.

Repro:
![image](https://github.com/user-attachments/assets/119c9a17-652a-4a6e-88a9-108d347f6f55)
```shell
> grep -E '^(<<<<<<<|=======|>>>>>>>)' README.md
==========================================================
=============   MegaLinter, by OX.security   =============
=========  https://ox.security?ref=megalinter  ===========
==========================================================
```

Replaces https://github.com/super-linter/super-linter/pull/6374

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
