### PR TITLE
chore: disable fail-fast in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,14 +252,10 @@ jobs:
       - set-build-metadata
       - build-container-image
       - build-test-suite-matrix
-    # Don't fail the entire test suite when:
-    # - Running npm audit, so we can see test results even if there are
-    #   vulnerable dependencies that might be unrelated to the PR
-    # - Running the 'test' target because it runs all the tests, including the
-    #   ones that are allowed to fail
-    continue-on-error: ${{ matrix.test-case == 'npm-audit' || matrix.test-case == 'test' }}
     strategy:
-      fail-fast: true
+      # Continue running the rest of the test suite so we get feedback even if
+      # there are failures in certain tests, such as when running npm-audit
+      fail-fast: false
       matrix:
         test-case: ${{ fromJson(needs.build-test-suite-matrix.outputs.matrix) }}
         images:


### PR DESCRIPTION
Don't stop the test suite on test failures, and don't skip reporting failures on certain test failures.

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [ ] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [ ] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
