### PR TITLE
Shouldnt this be a function?

### DIFF
--- a/lib/functions/linterCommands.sh
+++ b/lib/functions/linterCommands.sh
@@ -73,7 +73,7 @@ function InitPowerShellCommand() {
   debug "PowerShell command after initialization: ${LINTER_COMMANDS_ARRAY_POWERSHELL[*]}"
 }
 
-AddOptionsToCommand() {
+function AddOptionsToCommand() {
   local -n COMMAND_ARRAY_NAME="${1}"
   local COMMAND_OPTIONS_TO_ADD="${2}"
   local COMMAND_OPTIONS_TO_ADD_ARRAY


### PR DESCRIPTION
<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [ ] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [ ] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.



Hey All!

Was running the super-linter and hit error:
```bash
2024-12-04 20:32:17 [INFO]   Stderr when running linters:
------
/action/lib/functions/linterCommands.sh: line 111: AddOptionsToCommand: command not found
/action/lib/functions/linterCommands.sh: line 111: AddOptionsToCommand: command not found
/action/lib/functions/linterCommands.sh: line 111: AddOptionsToCommand: command not found
/action/lib/functions/linterCommands.sh: line 111: AddOptionsToCommand: command not found
/action/lib/functions/linterCommands.sh: line 111: AddOptionsToCommand: command not found
------
```

I noticed I was using the option:
```yml
KUBERNETES_KUBECONFORM_OPTIONS: "-ignore-missing-schemas"
```

And it wasn't taking in my variable and complaining about missing schemas...

Hope this is right :)