### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,14 @@ env:
   LINTER_RULES_PATH: config/lint
 ```
 
+In order to facilitate migrations from using standalone linters to super-linter,
+the following linters don't follow the convention described above in this
+section, but rather they use their own mechanism to discover and load
+configuration files. To configure these linters, see:
+
+- [Prettier](https://prettier.io/docs/en/configuration)
+- [Commitlint](https://commitlint.js.org/reference/configuration.html#config-via-file)
+
 Some of the linters that super-linter provides can be configured to disable
 certain rules or checks, and to ignore certain files or part of them.
 


### PR DESCRIPTION
Mention linters that have their own configuration mechanism

Close #6505

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [ ] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
