### PR TITLE
feat: composer install with any php linters

### DIFF
--- a/docs/run-linter-locally.md
+++ b/docs/run-linter-locally.md
@@ -33,7 +33,7 @@ Notes:
 - If the default branch for your repository doesn't match the default, you can
   use the `DEFAULT_BRANCH` variable to set the default branch. For more
   information about the default value of the `DEFAULT_BRANCH` variable, see the
-  [README](../README.md).
+  [Readme](../README.md).
 - You can add as many configuration options as needed. Configuration options are
   documented in the [readme](../README.md#configure-super-linter).
 

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -293,9 +293,13 @@ function RunAdditionalInstalls() {
   ##################################
   # Run installs for Psalm and PHP #
   ##################################
-  if [ "${VALIDATE_PHP_PSALM}" == "true" ] && [ -e "${FILE_ARRAYS_DIRECTORY_PATH}/file-array-PHP_PSALM" ]; then
+  if [[ ("${VALIDATE_PHP:-"${VALIDATE_PHP_BUILTIN}"}" == "true" && -e "${FILE_ARRAYS_DIRECTORY_PATH}/file-array-PHP_BUILTIN") ]] ||
+    [[ ("${VALIDATE_PHP_BUILTIN}" == "true" && -e "${FILE_ARRAYS_DIRECTORY_PATH}/file-array-PHP_BUILTIN") ]] ||
+    [[ ("${VALIDATE_PHP_PHPCS}" == "true" && -e "${FILE_ARRAYS_DIRECTORY_PATH}/file-array-PHP_PHPCS") ]] ||
+    [[ ("${VALIDATE_PHP_PHPSTAN}" == "true" && -e "${FILE_ARRAYS_DIRECTORY_PATH}/file-array-PHP_PHPSTAN") ]] ||
+    [[ ("${VALIDATE_PHP_PSALM}" == "true" && -e "${FILE_ARRAYS_DIRECTORY_PATH}/file-array-PHP_PSALM") ]]; then
     # found PHP files and were validating it, need to composer install
-    info "Found PHP files to validate, and VALIDATE_PHP_PSALM is set to ${VALIDATE_PHP_PSALM}. Check if we need to run composer install"
+    info "Found PHP files to validate. Check if we need to run composer install"
     mapfile -t COMPOSER_FILE_ARRAY < <(find "${GITHUB_WORKSPACE}" -name composer.json 2>&1)
     debug "COMPOSER_FILE_ARRAY contents: ${COMPOSER_FILE_ARRAY[*]}"
     if [ "${#COMPOSER_FILE_ARRAY[@]}" -ne 0 ]; then


### PR DESCRIPTION
Install dependencies with Composer when any PHP linter is enabled and there are files to lint with that linter, not just when Psalm is enabled.

Close #6336
Close #6598
Close #6597

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
