### PR TITLE
fix: Skip symbolic links when passing files to Prettier

### DIFF
--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -25,6 +25,7 @@
     "**/test/linters/php_phpcs",
     "**/test/linters/php_phpstan",
     "**/test/linters/php_psalm",
+    "**/test/linters/prettier",
     "**/test/linters/protobuf",
     "**/test/linters/python_black",
     "**/test/linters/python_flake8",

--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -369,7 +369,11 @@ BuildFileArrays() {
     elif [ "${FILE_TYPE}" == "css" ] || [ "${FILE_TYPE}" == "scss" ] ||
       [ "${FILE_TYPE}" == "sass" ]; then
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-CSS"
-      echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-CSS_PRETTIER"
+      if IsNotSymbolicLink "${FILE}"; then
+        echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-CSS_PRETTIER"
+      else
+        debug "Skip adding ${FILE} to CSS_PRETTIER file array because Prettier doesn't support following symbolic links"
+      fi
     elif [ "${FILE_TYPE}" == "dart" ]; then
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-DART"
     # Use BASE_FILE here because FILE_TYPE is not reliable when there is no file extension
@@ -425,20 +429,36 @@ BuildFileArrays() {
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-GROOVY"
     elif [ "${FILE_TYPE}" == "html" ]; then
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-HTML"
-      echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-HTML_PRETTIER"
+      if IsNotSymbolicLink "${FILE}"; then
+        echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-HTML_PRETTIER"
+      else
+        debug "Skip adding ${FILE} to HTML_PRETTIER file array because Prettier doesn't support following symbolic links"
+      fi
     elif [ "${FILE_TYPE}" == "java" ]; then
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-JAVA"
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-GOOGLE_JAVA_FORMAT"
     elif [ "${FILE_TYPE}" == "js" ]; then
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-JAVASCRIPT_ES"
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-JAVASCRIPT_STANDARD"
-      echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-JAVASCRIPT_PRETTIER"
+      if IsNotSymbolicLink "${FILE}"; then
+        echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-JAVASCRIPT_PRETTIER"
+      else
+        debug "Skip adding ${FILE} to JAVASCRIPT_PRETTIER file array because Prettier doesn't support following symbolic links"
+      fi
     elif [ "$FILE_TYPE" == "jsonc" ] || [ "$FILE_TYPE" == "json5" ]; then
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-JSONC"
-      echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-JSONC_PRETTIER"
+      if IsNotSymbolicLink "${FILE}"; then
+        echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-JSONC_PRETTIER"
+      else
+        debug "Skip adding ${FILE} to JSONC_PRETTIER file array because Prettier doesn't support following symbolic links"
+      fi
     elif [ "${FILE_TYPE}" == "json" ]; then
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-JSON"
-      echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-JSON_PRETTIER"
+      if IsNotSymbolicLink "${FILE}"; then
+        echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-JSON_PRETTIER"
+      else
+        debug "Skip adding ${FILE} to JSON_PRETTIER file array because Prettier doesn't support following symbolic links"
+      fi
       if DetectOpenAPIFile "${FILE}"; then
         echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-OPENAPI"
       fi
@@ -456,7 +476,11 @@ BuildFileArrays() {
       fi
     elif [ "${FILE_TYPE}" == "jsx" ]; then
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-JSX"
-      echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-JSX_PRETTIER"
+      if IsNotSymbolicLink "${FILE}"; then
+        echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-JSX_PRETTIER"
+      else
+        debug "Skip adding ${FILE} to JSX_PRETTIER file array because Prettier doesn't support following symbolic links"
+      fi
     elif [ "${FILE_TYPE}" == "ipynb" ]; then
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-JUPYTER_NBQA_BLACK"
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-JUPYTER_NBQA_FLAKE8"
@@ -472,7 +496,11 @@ BuildFileArrays() {
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-LATEX"
     elif [ "${FILE_TYPE}" == "md" ]; then
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-MARKDOWN"
-      echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-MARKDOWN_PRETTIER"
+      if IsNotSymbolicLink "${FILE}"; then
+        echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-MARKDOWN_PRETTIER"
+      else
+        debug "Skip adding ${FILE} to MARKDOWN_PRETTIER file array because Prettier doesn't support following symbolic links"
+      fi
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-NATURAL_LANGUAGE"
     elif [ "${FILE_TYPE}" == "php" ]; then
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-PHP_BUILTIN"
@@ -534,7 +562,11 @@ BuildFileArrays() {
     elif [ "${FILE_TYPE}" == "ts" ]; then
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-TYPESCRIPT_ES"
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-TYPESCRIPT_STANDARD"
-      echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-TYPESCRIPT_PRETTIER"
+      if IsNotSymbolicLink "${FILE}"; then
+        echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-TYPESCRIPT_PRETTIER"
+      else
+        debug "Skip adding ${FILE} to TYPESCRIPT_PRETTIER file array because Prettier doesn't support following symbolic links"
+      fi
     elif [ "${FILE_TYPE}" == "tsx" ]; then
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-TSX"
     elif [ "${FILE_TYPE}" == "txt" ]; then
@@ -545,16 +577,28 @@ BuildFileArrays() {
     elif [[ "${FILE}" =~ .?goreleaser.+ya?ml ]]; then
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-GO_RELEASER"
     elif [ "${FILE_TYPE}" == "graphql" ]; then
-      echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-GRAPHQL_PRETTIER"
+      if IsNotSymbolicLink "${FILE}"; then
+        echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-GRAPHQL_PRETTIER"
+      else
+        debug "Skip adding ${FILE} to GRAPHQL_PRETTIER file array because Prettier doesn't support following symbolic links"
+      fi
     elif [ "${FILE_TYPE}" == "vue" ]; then
-      echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-VUE_PRETTIER"
+      if IsNotSymbolicLink "${FILE}"; then
+        echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-VUE_PRETTIER"
+      else
+        debug "Skip adding ${FILE} to VUE_PRETTIER file array because Prettier doesn't support following symbolic links"
+      fi
     elif [ "${FILE_TYPE}" == "sln" ]; then
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-DOTNET_SLN_FORMAT_ANALYZERS"
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-DOTNET_SLN_FORMAT_STYLE"
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-DOTNET_SLN_FORMAT_WHITESPACE"
     elif [ "${FILE_TYPE}" == "yml" ] || [ "${FILE_TYPE}" == "yaml" ]; then
       echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-YAML"
-      echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-YAML_PRETTIER"
+      if IsNotSymbolicLink "${FILE}"; then
+        echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-YAML_PRETTIER"
+      else
+        debug "Skip adding ${FILE} to YAML_PRETTIER file array because Prettier doesn't support following symbolic links"
+      fi
       if DetectActions "${FILE}"; then
         echo "${FILE}" >>"${FILE_ARRAYS_DIRECTORY_PATH}/file-array-GITHUB_ACTIONS"
       fi

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -269,6 +269,20 @@ function IsGenerated() {
   fi
 }
 
+function IsNotSymbolicLink() {
+  local FILE="$1"
+
+  debug "Checking if ${FILE} is not a symbolic link..."
+
+  if [[ -L "${FILE}" ]]; then
+    debug "${FILE} is a symbolic link"
+    return 1
+  else
+    debug "${FILE} is NOT a symbolic link"
+    return 0
+  fi
+}
+
 # We need these functions when building the file list with parallel
 export -f CheckFileType
 export -f DetectActions
@@ -283,6 +297,7 @@ export -f GetFileType
 export -f IsValidShellScript
 export -f HasNoShebang
 export -f IsGenerated
+export -f IsNotSymbolicLink
 
 function RunAdditionalInstalls() {
 

--- a/test/lib/detectFilesTest.sh
+++ b/test/lib/detectFilesTest.sh
@@ -124,11 +124,43 @@ function IsAnsibleDirectoryTest() {
   notice "${FUNCTION_NAME} PASS"
 }
 
+function RecognizeNotSymbolicLink() {
+  local FUNCTION_NAME
+  FUNCTION_NAME="${FUNCNAME[0]}"
+  info "${FUNCTION_NAME} start"
+  local FILE="test/linters/symboliclinks/not_symbolic_link"
+
+  debug "Confirming that ${FILE} is not a symbolic link"
+
+  if ! IsNotSymbolicLink "${FILE}"; then
+    fatal "${FILE} is a symbolic link"
+  fi
+
+  notice "${FUNCTION_NAME} PASS"
+}
+
+function RecognizeSymbolicLink() {
+  local FUNCTION_NAME
+  FUNCTION_NAME="${FUNCNAME[0]}"
+  info "${FUNCTION_NAME} start"
+  local FILE="test/linters/symboliclinks/symbolic_link"
+
+  debug "Confirming that ${FILE} is a symbolic link"
+
+  if IsNotSymbolicLink "${FILE}"; then
+    fatal "${FILE} is not a symbolic link"
+  fi
+
+  notice "${FUNCTION_NAME} PASS"
+}
+
 RecognizeNoShebangTest
 RecognizeCommentIsNotShebangTest
 RecognizeIndentedShebangAsCommentTest
 RecognizeSecondLineShebangAsCommentTest
 RecognizeShebangTest
 RecognizeShebangWithBlankTest
+RecognizeNotSymbolicLink
+RecognizeSymbolicLink
 
 IsAnsibleDirectoryTest

--- a/test/linters/README.md
+++ b/test/linters/README.md
@@ -47,3 +47,8 @@ up.
 ### Ansible test cases
 
 `roles/ghe-initialize` is a valid Ansible role
+
+### Symbolic Links test cases
+
+- `symboliclinks/notSymbolicLink` is not a symbolic link
+- `symboliclinks/symbolicLink` is a symbolic link

--- a/test/linters/prettier/test_symlink_good.md
+++ b/test/linters/prettier/test_symlink_good.md
@@ -1,0 +1,1 @@
+../README.md

--- a/test/linters/symboliclinks/symbolic_link
+++ b/test/linters/symboliclinks/symbolic_link
@@ -1,0 +1,1 @@
+not_symbolic_link


### PR DESCRIPTION
Skip symbolic links when passing files to Prettier

- Fix #6378
- [`lib/functions/detectFiles.sh`]: Add `IsNotSymbolicLink()` function
  to check whether provided file is symbolic link or not
- [`lib/functions/buildFileList.sh`]: Use `IsNotSymbolicLink()` function
  to not add files that are symbolic links to the file array for
  Prettier
- [`test/lib/detectFilesTest.sh`]: Add test for `IsNotSymbolicLink()`
  function
<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [ ] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [ ] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [ ] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
