### PR TITLE
fix: emit prettier verbose output when debugging

### DIFF
--- a/lib/functions/output.sh
+++ b/lib/functions/output.sh
@@ -42,6 +42,12 @@ WriteSummaryFooterFailure() {
 FormatSuperLinterSummaryFile() {
   local SUPER_LINTER_SUMMARY_OUTPUT_PATH="${1}"
   local SUPER_LINTER_SUMMARY_FORMAT_COMMAND=(prettier --write)
+
+  # Avoid emitting output except of warnings and errors if debug logging is
+  # disabled.
+  if [[ "${LOG_DEBUG}" != "true" ]]; then
+    SUPER_LINTER_SUMMARY_FORMAT_COMMAND+=(--log-level warn)
+  fi
   # Override the default prettier ignore paths (.gitignore, .prettierignore) to
   # avoid considering their defaults because prettier will skip formatting
   # the summary report file if the summary report file is ignored in those


### PR DESCRIPTION
Set Prettier output to warn unless Super-linter debug output is enabled to avoid that Prettier prints its default output when formatting the summary file, potentially confusing users.

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
