### PR TITLE
feat: do not hide php composer output

### DIFF
--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -323,7 +323,10 @@ function RunAdditionalInstalls() {
         COMPOSER_PATH=$(dirname "${LINE}" 2>&1)
         info "Found Composer file: ${LINE}"
         local COMPOSER_CMD
-        if ! COMPOSER_CMD=$(cd "${COMPOSER_PATH}" && composer install --no-progress -q 2>&1); then
+        local COMPOSER_EXIT_STATUS
+        COMPOSER_CMD=$(cd "${COMPOSER_PATH}" && composer install --no-progress 2>&1)
+        COMPOSER_EXIT_STATUS=$?
+        if [ $COMPOSER_EXIT_STATUS -ne 0 ]; then
           fatal "Failed to run composer install for ${COMPOSER_PATH}. Output: ${COMPOSER_CMD}"
         else
           info "Successfully ran composer install."

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -315,11 +315,7 @@ function RunAdditionalInstalls() {
     [[ ("${VALIDATE_PHP_PSALM}" == "true" && -e "${FILE_ARRAYS_DIRECTORY_PATH}/file-array-PHP_PSALM") ]]; then
     # found PHP files and were validating it, need to composer install
     info "Found PHP files to validate. Check if we need to run composer install"
-    if [[ -n "${FILTER_REGEX_EXCLUDE}" ]]; then
-      mapfile -t COMPOSER_FILE_ARRAY < <(find "${GITHUB_WORKSPACE}" -name composer.json ! -regex "${FILTER_REGEX_EXCLUDE}" 2>&1)
-    else
-      mapfile -t COMPOSER_FILE_ARRAY < <(find "${GITHUB_WORKSPACE}" -name composer.json 2>&1)
-    fi
+    mapfile -t COMPOSER_FILE_ARRAY < <(find "${GITHUB_WORKSPACE}" -name composer.json 2>&1)
     debug "COMPOSER_FILE_ARRAY contents: ${COMPOSER_FILE_ARRAY[*]}"
     if [ "${#COMPOSER_FILE_ARRAY[@]}" -ne 0 ]; then
       for LINE in "${COMPOSER_FILE_ARRAY[@]}"; do
@@ -328,9 +324,9 @@ function RunAdditionalInstalls() {
         info "Found Composer file: ${LINE}"
         local COMPOSER_CMD
         local COMPOSER_EXIT_STATUS
-        COMPOSER_CMD=$(cd "${COMPOSER_PATH}" && composer install --ignore-platform-reqs --no-plugins --no-progress --no-scripts 2>&1)
+        COMPOSER_CMD=$(cd "${COMPOSER_PATH}" && composer install --no-progress 2>&1)
         COMPOSER_EXIT_STATUS=$?
-        if [ $COMPOSER_EXIT_STATUS -ne 0 ]; then
+        if [ "${COMPOSER_EXIT_STATUS}" -ne 0 ]; then
           fatal "Failed to run composer install for ${COMPOSER_PATH}. Output: ${COMPOSER_CMD}"
         else
           info "Successfully ran composer install."

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -315,7 +315,11 @@ function RunAdditionalInstalls() {
     [[ ("${VALIDATE_PHP_PSALM}" == "true" && -e "${FILE_ARRAYS_DIRECTORY_PATH}/file-array-PHP_PSALM") ]]; then
     # found PHP files and were validating it, need to composer install
     info "Found PHP files to validate. Check if we need to run composer install"
-    mapfile -t COMPOSER_FILE_ARRAY < <(find "${GITHUB_WORKSPACE}" -name composer.json 2>&1)
+    if [[ -n "${FILTER_REGEX_EXCLUDE}" ]]; then
+      mapfile -t COMPOSER_FILE_ARRAY < <(find "${GITHUB_WORKSPACE}" -name composer.json ! -regex "${FILTER_REGEX_EXCLUDE}" 2>&1)
+    else
+      mapfile -t COMPOSER_FILE_ARRAY < <(find "${GITHUB_WORKSPACE}" -name composer.json 2>&1)
+    fi
     debug "COMPOSER_FILE_ARRAY contents: ${COMPOSER_FILE_ARRAY[*]}"
     if [ "${#COMPOSER_FILE_ARRAY[@]}" -ne 0 ]; then
       for LINE in "${COMPOSER_FILE_ARRAY[@]}"; do

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -328,7 +328,7 @@ function RunAdditionalInstalls() {
         info "Found Composer file: ${LINE}"
         local COMPOSER_CMD
         local COMPOSER_EXIT_STATUS
-        COMPOSER_CMD=$(cd "${COMPOSER_PATH}" && composer install --ignore-platform-reqs --no-progress 2>&1)
+        COMPOSER_CMD=$(cd "${COMPOSER_PATH}" && composer install --ignore-platform-reqs --no-plugins --no-progress --no-scripts 2>&1)
         COMPOSER_EXIT_STATUS=$?
         if [ $COMPOSER_EXIT_STATUS -ne 0 ]; then
           fatal "Failed to run composer install for ${COMPOSER_PATH}. Output: ${COMPOSER_CMD}"

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -324,7 +324,7 @@ function RunAdditionalInstalls() {
         info "Found Composer file: ${LINE}"
         local COMPOSER_CMD
         local COMPOSER_EXIT_STATUS
-        COMPOSER_CMD=$(cd "${COMPOSER_PATH}" && composer install --no-progress 2>&1)
+        COMPOSER_CMD=$(cd "${COMPOSER_PATH}" && composer install --ignore-platform-reqs --no-progress 2>&1)
         COMPOSER_EXIT_STATUS=$?
         if [ $COMPOSER_EXIT_STATUS -ne 0 ]; then
           fatal "Failed to run composer install for ${COMPOSER_PATH}. Output: ${COMPOSER_CMD}"


### PR DESCRIPTION
As "composer install with any php linters" since v7.3.0, exclude third-party libraries and improve diagnostics

### Enhanced Composer Output
Composer now always outputs complete problem descriptions by capturing the exit status separately. This ensures that even if Composer produces output on both success and failure, failures are reliably detected—replacing vague error messages with detailed explanations.

### Bypass Platform Dependency Checks (moved to a separate PR)
In the super-linter environment, where certain PHP extensions may be missing, Composer install now runs with the --ignore-platform-reqs flag. This prevents failures due to environment-specific missing dependencies.
Also flags --no-plugins and --no-scripts have been added to `composer install` to disable plugins and scripts during package installation or updates. This ensures that only Composer's code is executed, preventing any third-party code from running.

### Filtered Search for composer.json (moved to a separate PR)
The search for composer.json files now applies FILTER_REGEX_EXCLUDE to filter out paths that should not be processed (e.g., vendor directories), ensuring that only relevant files are considered.

**Recommendation:** add `FILTER_REGEX_EXCLUDE: '.*\/vendor\/.*'` to the environment variables to exclude automatically downloaded dependencies. Additionally, add the following configuration to `.github/linters/.checkov.yaml`:

```bash
skip-path:
  # composer dependencies
  - vendor
```

Close #6635 

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [ ] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [ ] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
