### PR TITLE
chore: use python venv instead of virtualenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ RUN apk add --no-cache \
 SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
 
 COPY dependencies/python/ /stage
+COPY scripts/build-venvs.sh /stage/
 WORKDIR /stage
 RUN ./build-venvs.sh && rm -rfv /stage
 
@@ -495,7 +496,7 @@ ARG TARGETARCH
 ENV ARM_TTK_PSD1="/usr/lib/microsoft/arm-ttk/arm-ttk.psd1"
 ENV PATH="${PATH}:/var/cache/dotnet/tools:/usr/share/dotnet"
 
-# Install super-linter runtime dependencies
+# Install Rust linters
 RUN apk add --no-cache \
   rust-clippy \
   rustfmt

--- a/scripts/build-venvs.sh
+++ b/scripts/build-venvs.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
-################################################################################
-########################### Install Python Dependancies ########################
-################################################################################
 
-#####################
-# Set fail on error #
-#####################
-set -euo pipefail
+set -o errexit
+set -o nounset
+set -o pipefail
 
 apk add --no-cache --virtual .python-build-deps \
   gcc \
@@ -24,11 +20,6 @@ export CXXFLAGS="-Wno-error=incompatible-pointer-types"
 ############################
 mkdir -p /venvs
 
-########################################
-# Install basic libs to run installers #
-########################################
-pip install virtualenv
-
 #######################################################
 # Iterate through requirments.txt to install binaries #
 #######################################################
@@ -40,7 +31,7 @@ for DEP_FILE in *.txt; do
   cp "${DEP_FILE}" "/venvs/${PACKAGE_NAME}/requirements.txt"
   echo "Generating virtualenv for: [${PACKAGE_NAME}]"
   pushd "/venvs/${PACKAGE_NAME}"
-  virtualenv .
+  python -m venv .
   # shellcheck disable=SC1091
   source bin/activate
   pip install \


### PR DESCRIPTION
Use python venv instead of installing virtualenv to avoid maintaining another pip requirements file.

Related to #4986

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
