### PR TITLE
chore: cache multi-stage build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,8 +9,69 @@ on:
 permissions: {}
 
 jobs:
+  build-stages:
+    name: Build and cache container image stages
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-main-build-stages-${{ matrix.stages.stage-name }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      issues: write
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        stages:
+          - stage-name: clang-format
+          - stage-name: python-builder
+          - stage-name: npm-builder
+          - stage-name: tflint-plugins
+          - stage-name: lintr-installer
+          - stage-name: powershell-installer
+          - stage-name: php-linters
+    timeout-minutes: 120
+    env:
+      CONTAINER_IMAGE_ID: "ghcr.io/super-linter/super-linter:latest"
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build clang-format stage
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          cache-from: type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-${{ matrix.stages.stage-name }}
+          cache-to: type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-${{ matrix.stages.stage-name }},mode=max
+          load: false
+          push: false
+          secrets: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          target: ${{ matrix.stages.stage-name }}
+      - name: Create Issue on Failure
+        uses: actions/github-script@v7
+        if: failure()
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const create = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: "Failed to build stage ${{ matrix.stages.stage-name }}",
+              body: "Automation has failed us!\nMore information can be found at:\n - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              assignees: [
+                "zkoppert", "Hanse00", "ferrarimarco"
+              ]
+            })
+
   test:
     name: Build and Test
+    needs:
+      - build-stages
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-main-${{ matrix.images.target }}
@@ -95,7 +156,15 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             BUILD_REVISION=${{ env.BUILD_REVISION }}
             BUILD_VERSION=${{ env.BUILD_VERSION }}
-          cache-from: type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache
+          cache-from: |
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-clang-format
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-python-builder
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-npm-builder
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-tflint-plugins
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-lintr-installer
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-powershell-installer
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-php-linters
           load: true
           push: false
           secrets: |
@@ -125,7 +194,15 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             BUILD_REVISION=${{ env.BUILD_REVISION }}
             BUILD_VERSION=${{ env.BUILD_VERSION }}
-          cache-from: type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache
+          cache-from: |
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-clang-format
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-python-builder
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-npm-builder
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-tflint-plugins
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-lintr-installer
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-powershell-installer
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-php-linters
           cache-to: type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache,mode=max
           load: false
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,47 @@ jobs:
             echo "CONTAINER_IMAGE_BUILD_VERSION=${BUILD_VERSION}"
           } >> "${GITHUB_OUTPUT}"
 
+  build-stages:
+    name: Build and cache container image stages
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-${{ github.event_name }}-build-stages-${{ matrix.stages.stage-name }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        stages:
+          - stage-name: clang-format
+          - stage-name: python-builder
+          - stage-name: npm-builder
+          - stage-name: tflint-plugins
+          - stage-name: lintr-installer
+          - stage-name: powershell-installer
+          - stage-name: php-linters
+    timeout-minutes: 120
+    env:
+      CONTAINER_IMAGE_ID: "ghcr.io/super-linter/super-linter:latest"
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build ${{ matrix.stages.stage-name }} stage
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          cache-from: type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-${{ matrix.stages.stage-name }}
+          load: false
+          push: false
+          secrets: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          target: ${{ matrix.stages.stage-name }}
+
   build-container-image:
     name: Build and Test
     runs-on: ubuntu-latest
@@ -127,7 +168,15 @@ jobs:
             BUILD_DATE=${{ needs.set-build-metadata.outputs.CONTAINER_IMAGE_BUILD_DATE }}
             BUILD_REVISION=${{ needs.set-build-metadata.outputs.CONTAINER_IMAGE_BUILD_REVISION }}
             BUILD_VERSION=${{ needs.set-build-metadata.outputs.CONTAINER_IMAGE_BUILD_VERSION }}
-          cache-from: type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache
+          cache-from: |
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-clang-format
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-python-builder
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-npm-builder
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-tflint-plugins
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-lintr-installer
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-powershell-installer
+            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-php-linters
           outputs: type=docker,dest=/tmp/${{ env.CONTAINER_IMAGE_OUTPUT_IMAGE_NAME }}.tar
           push: false
           secrets: |


### PR DESCRIPTION
Cache all the stages of the multi-stage build

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
