### PR TITLE
feat: set github_before_sha on pull requests

### DIFF
--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -11,24 +11,20 @@ function IssueHintForFullGitHistory() {
 export -f IssueHintForFullGitHistory
 
 function GenerateFileDiff() {
-  local DIFF_GIT_DEFAULT_BRANCH_CMD
-  DIFF_GIT_DEFAULT_BRANCH_CMD="git -C \"${GITHUB_WORKSPACE}\" diff --diff-filter=d --name-only ${DEFAULT_BRANCH}...${GITHUB_SHA} | xargs -I % sh -c 'echo \"${GITHUB_WORKSPACE}/%\"' 2>&1"
-
-  if [ "${GITHUB_EVENT_NAME:-}" == "push" ]; then
-    local DIFF_TREE_CMD
-    if [[ "${GITHUB_SHA}" == "${GIT_ROOT_COMMIT_SHA}" ]]; then
-      GITHUB_BEFORE_SHA=""
-      debug "Set GITHUB_BEFORE_SHA (${GITHUB_BEFORE_SHA}) to an empty string because there's no commit before the initial commit to diff against."
-    fi
-    DIFF_TREE_CMD="git -C \"${GITHUB_WORKSPACE}\" diff-tree --no-commit-id --name-only -r --root ${GITHUB_SHA} ${GITHUB_BEFORE_SHA} | xargs -I % sh -c 'echo \"${GITHUB_WORKSPACE}/%\"' 2>&1"
-    RunFileDiffCommand "${DIFF_TREE_CMD}"
-    if [ ${#RAW_FILE_ARRAY[@]} -eq 0 ]; then
-      debug "Generating the file array with diff-tree produced [0] items, trying with git diff against the default branch..."
-      RunFileDiffCommand "${DIFF_GIT_DEFAULT_BRANCH_CMD}"
-    fi
+  local DIFF_TREE_CMD
+  local GIT_DIFF_TERM
+  if [[ "${GITHUB_SHA}" == "${GIT_ROOT_COMMIT_SHA}" ]]; then
+    GIT_DIFF_TERM=""
+    debug "Setting GIT_DIFF_TERM to an empty string because there's no commit before the initial commit to diff against."
+  elif [[ -z "${GITHUB_BEFORE_SHA:-""}" ]]; then
+    GIT_DIFF_TERM="${DEFAULT_BRANCH}"
+    debug "Setting GIT_DIFF_TERM to the value of DEFAULT_BRANCH because GITHUB_BEFORE_SHA was not initialized: ${GIT_DIFF_TERM}"
   else
-    RunFileDiffCommand "${DIFF_GIT_DEFAULT_BRANCH_CMD}"
+    GIT_DIFF_TERM="${GITHUB_BEFORE_SHA}"
+    debug "Setting GIT_DIFF_TERM to the value of GITHUB_BEFORE_SHA: ${GIT_DIFF_TERM}"
   fi
+  DIFF_TREE_CMD="git -C \"${GITHUB_WORKSPACE}\" diff-tree --no-commit-id --name-only -r --root ${GITHUB_SHA} ${GIT_DIFF_TERM} | xargs -I % sh -c 'echo \"${GITHUB_WORKSPACE}/%\"' 2>&1"
+  RunFileDiffCommand "${DIFF_TREE_CMD}"
 }
 
 function RunFileDiffCommand() {

--- a/test/lib/buildFileListTest.sh
+++ b/test/lib/buildFileListTest.sh
@@ -84,6 +84,11 @@ GenerateFileDiffInitialCommitPushEventTest() {
 }
 GenerateFileDiffInitialCommitPushEventTest
 
+GenerateFileDiffPushEventNoGitHubBeforeShaTest() {
+  GenerateFileDiffTest "${FUNCNAME[0]}" 2 "push" "true"
+}
+GenerateFileDiffPushEventNoGitHubBeforeShaTest
+
 GenerateFileDiffOneFilePullRequestEventTest() {
   GenerateFileDiffTest "${FUNCNAME[0]}" 1 "pull_request" "false"
 }

--- a/test/lib/validationTest.sh
+++ b/test/lib/validationTest.sh
@@ -560,6 +560,76 @@ ValidateCommitlintConfigurationTest() {
   notice "${FUNCTION_NAME} PASS"
 }
 
+InitializeAndValidateGitBeforeShaReferenceFastForwardPushTest() {
+  local FUNCTION_NAME
+  FUNCTION_NAME="${FUNCNAME[0]}"
+  info "${FUNCTION_NAME} start"
+
+  GITHUB_WORKSPACE="$(mktemp -d)"
+  initialize_git_repository "${GITHUB_WORKSPACE}"
+
+  local -i COMMIT_COUNT=3
+
+  for ((i = 0; i < COMMIT_COUNT; i++)); do
+    touch "${GITHUB_WORKSPACE}/file-${i}.txt"
+    git -C "${GITHUB_WORKSPACE}" add .
+    git -C "${GITHUB_WORKSPACE}" commit -m "add file-${i}"
+
+    # Set EXPECTED_GITHUB_BEFORE_SHA to the initial commit because it's the only
+    # one we don't push
+    if [[ "${i}" -eq 0 ]]; then
+      local EXPECTED_GITHUB_BEFORE_SHA
+      EXPECTED_GITHUB_BEFORE_SHA="$(git -C "${GITHUB_WORKSPACE}" rev-parse HEAD)"
+      debug "Setting EXPECTED_GITHUB_BEFORE_SHA to ${EXPECTED_GITHUB_BEFORE_SHA}"
+    fi
+  done
+
+  git_log_graph "${GITHUB_WORKSPACE}"
+
+  initialize_github_sha "${GITHUB_WORKSPACE}"
+
+  # Simulate pushing all the commits besides the initial one
+  InitializeAndValidateGitBeforeShaReference "${GITHUB_SHA}" "((${COMMIT_COUNT}-1))" "${EXPECTED_GITHUB_BEFORE_SHA}"
+
+  if [[ "${GITHUB_BEFORE_SHA}" != "${EXPECTED_GITHUB_BEFORE_SHA}" ]]; then
+    fatal "GITHUB_BEFORE_SHA (${GITHUB_BEFORE_SHA}) is not equal to the expected value: ${EXPECTED_GITHUB_BEFORE_SHA}"
+  else
+    debug "GITHUB_BEFORE_SHA (${GITHUB_BEFORE_SHA}) matches the expected value: ${EXPECTED_GITHUB_BEFORE_SHA}"
+  fi
+
+  notice "${FUNCTION_NAME} PASS"
+}
+
+InitializeAndValidateGitBeforeShaReferenceMergeCommitPushTest() {
+  local FUNCTION_NAME
+  FUNCTION_NAME="${FUNCNAME[0]}"
+  info "${FUNCTION_NAME} start"
+
+  GITHUB_WORKSPACE="$(mktemp -d)"
+  initialize_git_repository "${GITHUB_WORKSPACE}"
+
+  local -i COMMIT_COUNT=3
+
+  initialize_git_repository_contents "${GITHUB_WORKSPACE}" "${COMMIT_COUNT}" "true" "pull_request" "true" "false"
+
+  local EXPECTED_GITHUB_BEFORE_SHA="${GIT_ROOT_COMMIT_SHA}"
+  debug "Setting EXPECTED_GITHUB_BEFORE_SHA to ${EXPECTED_GITHUB_BEFORE_SHA}"
+
+  GITHUB_SHA="${GITHUB_PULL_REQUEST_HEAD_SHA}"
+  debug "Updating GITHUB_SHA to the pull request head SHA for the ${FUNCTION_NAME} test: ${GITHUB_SHA}"
+
+  # Simulate pushing all the commits besides the initial one
+  InitializeAndValidateGitBeforeShaReference "${GITHUB_SHA}" "((${COMMIT_COUNT}))" "${EXPECTED_GITHUB_BEFORE_SHA}"
+
+  if [[ "${GITHUB_BEFORE_SHA}" != "${EXPECTED_GITHUB_BEFORE_SHA}" ]]; then
+    fatal "GITHUB_BEFORE_SHA (${GITHUB_BEFORE_SHA}) is not equal to the expected value: ${EXPECTED_GITHUB_BEFORE_SHA}"
+  else
+    debug "GITHUB_BEFORE_SHA (${GITHUB_BEFORE_SHA}) matches the expected value: ${EXPECTED_GITHUB_BEFORE_SHA}"
+  fi
+
+  notice "${FUNCTION_NAME} PASS"
+}
+
 InitializeRootCommitShaTest() {
   local FUNCTION_NAME
   FUNCTION_NAME="${FUNCNAME[0]}"
@@ -594,4 +664,6 @@ ValidationVariablesExportTest
 ValidateCheckModeAndFixModeVariablesTest
 CheckIfFixModeIsEnabledTest
 ValidateCommitlintConfigurationTest
+InitializeAndValidateGitBeforeShaReferenceFastForwardPushTest
+InitializeAndValidateGitBeforeShaReferenceMergeCommitPushTest
 InitializeRootCommitShaTest


### PR DESCRIPTION
- Extract the logic to initialize GITHUB_BEFORE_SHA in a function
  (InitializeAndValidateGitBeforeSha).
- Set GITHUB_BEFORE_SHA for pull requests, not just for pushes. The side
  effect of this is that commitlint can now lint all the commits that
  are in a pull request when super-linter is triggered by a
  pull_request event, instead of linting only the last commit.
- Simplify the GenerateFileDiff function by using only the git diff-tree
  command (a plumbing command), for both pull requests and pushes,
  instead of using the git diff-tree command for pushes, and the git
  diff command (a non-plumbing command) for pull requests.

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
