### PR TITLE
chore: cache the base image stage

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         stages:
+          - stage-name: base_image
           - stage-name: clang-format
           - stage-name: python-builder
           - stage-name: npm-builder
@@ -99,6 +100,7 @@ jobs:
     env:
       CONTAINER_IMAGE_ID: "ghcr.io/super-linter/super-linter:${{ matrix.images.prefix }}latest"
       CONTAINER_IMAGE_TARGET: "${{ matrix.images.target }}"
+      STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID: "ghcr.io/super-linter/super-linter:latest"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -165,13 +167,14 @@ jobs:
             BUILD_VERSION=${{ env.BUILD_VERSION }}
           cache-from: |
             type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-clang-format
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-python-builder
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-npm-builder
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-tflint-plugins
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-lintr-installer
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-powershell-installer
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-php-linters
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-base_image
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-clang-format
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-python-builder
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-npm-builder
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-tflint-plugins
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-lintr-installer
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-powershell-installer
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-php-linters
           load: true
           push: false
           secrets: |
@@ -203,13 +206,14 @@ jobs:
             BUILD_VERSION=${{ env.BUILD_VERSION }}
           cache-from: |
             type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-clang-format
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-python-builder
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-npm-builder
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-tflint-plugins
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-lintr-installer
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-powershell-installer
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-php-linters
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-base_image
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-clang-format
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-python-builder
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-npm-builder
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-tflint-plugins
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-lintr-installer
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-powershell-installer
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-php-linters
           cache-to: type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache,mode=max
           load: false
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
       fail-fast: false
       matrix:
         stages:
+          - stage-name: base_image
           - stage-name: clang-format
           - stage-name: python-builder
           - stage-name: npm-builder
@@ -142,6 +143,7 @@ jobs:
       CONTAINER_IMAGE_ID: "ghcr.io/super-linter/super-linter:${{ matrix.images.prefix }}latest"
       CONTAINER_IMAGE_TARGET: "${{ matrix.images.target }}"
       CONTAINER_IMAGE_OUTPUT_IMAGE_NAME: "super-linter-${{ matrix.images.prefix }}latest"
+      STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID: "ghcr.io/super-linter/super-linter:latest"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -170,13 +172,14 @@ jobs:
             BUILD_VERSION=${{ needs.set-build-metadata.outputs.CONTAINER_IMAGE_BUILD_VERSION }}
           cache-from: |
             type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-clang-format
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-python-builder
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-npm-builder
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-tflint-plugins
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-lintr-installer
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-powershell-installer
-            type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache-php-linters
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-base_image
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-clang-format
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-python-builder
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-npm-builder
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-tflint-plugins
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-lintr-installer
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-powershell-installer
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-php-linters
           outputs: type=docker,dest=/tmp/${{ env.CONTAINER_IMAGE_OUTPUT_IMAGE_NAME }}.tar
           push: false
           secrets: |

--- a/Makefile
+++ b/Makefile
@@ -35,12 +35,16 @@ IMAGE := $(CONTAINER_IMAGE_TARGET)
 
 # Default to stadard
 ifeq ($(IMAGE),)
-IMAGE := "standard"
+IMAGE := standard
+IMAGE_PREFIX :=
+endif
+ifeq ($(IMAGE),slim)
+IMAGE_PREFIX := slim-
 endif
 
 # Default to latest
 ifeq ($(SUPER_LINTER_TEST_CONTAINER_URL),)
-SUPER_LINTER_TEST_CONTAINER_URL := "ghcr.io/super-linter/super-linter:latest"
+SUPER_LINTER_TEST_CONTAINER_URL := "ghcr.io/super-linter/super-linter:${IMAGE_PREFIX}latest"
 endif
 
 ifeq ($(BUILD_DATE),)
@@ -82,6 +86,7 @@ info: ## Gather information about the runtime environment
 	echo "whoami: $$(whoami)"; \
 	echo "pwd: $$(pwd)"; \
 	echo "IMAGE:" $(IMAGE); \
+	echo "IMAGE_PREFIX: $(IMAGE_PREFIX)"; \
 	echo "Build date: ${BUILD_DATE}"; \
 	echo "Build revision: ${BUILD_REVISION}"; \
 	echo "Build version: ${BUILD_VERSION}"; \
@@ -127,6 +132,15 @@ docker: docker-build-check check-github-token ## Build the container image
 		--build-arg BUILD_DATE=$(BUILD_DATE) \
 		--build-arg BUILD_REVISION=$(BUILD_REVISION) \
 		--build-arg BUILD_VERSION=$(BUILD_VERSION) \
+		--cache-from type=registry,ref=ghcr.io/super-linter/super-linter:${IMAGE_PREFIX}latest-buildcache \
+		--cache-from type=registry,ref=ghcr.io/super-linter/super-linter:latest-buildcache-base_image \
+		--cache-from type=registry,ref=ghcr.io/super-linter/super-linter:latest-buildcache-clang-format \
+		--cache-from type=registry,ref=ghcr.io/super-linter/super-linter:latest-buildcache-python-builder \
+		--cache-from type=registry,ref=ghcr.io/super-linter/super-linter:latest-buildcache-npm-builder \
+		--cache-from type=registry,ref=ghcr.io/super-linter/super-linter:latest-buildcache-tflint-plugins \
+		--cache-from type=registry,ref=ghcr.io/super-linter/super-linter:latest-buildcache-lintr-installer \
+		--cache-from type=registry,ref=ghcr.io/super-linter/super-linter:latest-buildcache-powershell-installer \
+		--cache-from type=registry,ref=ghcr.io/super-linter/super-linter:latest-buildcache-php-linters \
 		--secret id=GITHUB_TOKEN,src=$(GITHUB_TOKEN_PATH) \
 		--target $(IMAGE) \
 		-t $(SUPER_LINTER_TEST_CONTAINER_URL) .


### PR DESCRIPTION
Cache the base_image stage, and update the docker target in Makefile to benefit from the cache.

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
