### PR TITLE
feat: disable xmllint verbose output if debuging

### DIFF
--- a/lib/functions/linterCommands.sh
+++ b/lib/functions/linterCommands.sh
@@ -268,6 +268,11 @@ LINTER_COMMANDS_ARRAY_TYPESCRIPT_PRETTIER=("${PRETTIER_COMMAND[@]}")
 LINTER_COMMANDS_ARRAY_TYPESCRIPT_STANDARD=(ts-standard --parser @typescript-eslint/parser --plugin @typescript-eslint/eslint-plugin --project "${TYPESCRIPT_STANDARD_TSCONFIG_FILE}")
 LINTER_COMMANDS_ARRAY_VUE_PRETTIER=("${PRETTIER_COMMAND[@]}")
 LINTER_COMMANDS_ARRAY_XML=(xmllint)
+# Avoid emitting output except of warnings and errors if debug logging is
+# disabled.
+if [[ "${LOG_DEBUG}" == "false" ]]; then
+  LINTER_COMMANDS_ARRAY_XML+=("${XMLLINT_NOOUT_OPTIONS[@]}")
+fi
 LINTER_COMMANDS_ARRAY_YAML=(yamllint -c "${YAML_LINTER_RULES}" -f parsable)
 if [ "${YAML_ERROR_ON_WARNING}" == 'true' ]; then
   LINTER_COMMANDS_ARRAY_YAML+=(--strict)

--- a/lib/globals/linterCommandsOptions.sh
+++ b/lib/globals/linterCommandsOptions.sh
@@ -107,3 +107,5 @@ INPUT_CONSUME_COMMAND=("&& echo \"Linted: {}\"")
 COMMITLINT_STRICT_MODE_OPTIONS=("--strict")
 
 GITLEAKS_LOG_LEVEL_OPTIONS=("--log-level")
+
+XMLLINT_NOOUT_OPTIONS=("--noout")

--- a/test/lib/linterCommandsTest.sh
+++ b/test/lib/linterCommandsTest.sh
@@ -65,6 +65,7 @@ BASE_LINTER_COMMANDS_ARRAY_JSCPD=("${LINTER_COMMANDS_ARRAY_JSCPD[@]}")
 BASE_LINTER_COMMANDS_ARRAY_KUBERNETES_KUBECONFORM=("${LINTER_COMMANDS_ARRAY_KUBERNETES_KUBECONFORM[@]}")
 BASE_LINTER_COMMANDS_ARRAY_PERL=("${LINTER_COMMANDS_ARRAY_PERL[@]}")
 BASE_LINTER_COMMANDS_ARRAY_RUST_CLIPPY=("${LINTER_COMMANDS_ARRAY_RUST_CLIPPY[@]}")
+BASE_LINTER_COMMANDS_ARRAY_XML=("${LINTER_COMMANDS_ARRAY_XML[@]}")
 
 function LinterCommandPresenceTest() {
   local FUNCTION_NAME
@@ -244,6 +245,44 @@ function InitInputConsumeCommandsTest() {
   notice "${FUNCTION_NAME} PASS"
 }
 
+AddDebugOptionsToCommandsTest() {
+  local FUNCTION_NAME
+  FUNCTION_NAME="${FUNCNAME[0]}"
+  info "${FUNCTION_NAME} start"
+
+  local LOG_DEBUG="true"
+
+  # Source the file again so it accounts for modifications
+  # shellcheck source=/dev/null
+  source "lib/functions/linterCommands.sh"
+
+  # shellcheck disable=SC2034
+  EXPECTED_LINTER_COMMANDS_ARRAY_XML=("${BASE_LINTER_COMMANDS_ARRAY_XML[@]}")
+
+  if ! AssertArraysElementsContentMatch "LINTER_COMMANDS_ARRAY_XML" "EXPECTED_LINTER_COMMANDS_ARRAY_XML"; then
+    fatal "${FUNCTION_NAME} test failed"
+  fi
+
+  LOG_DEBUG="false"
+
+  # Source the file again so it accounts for modifications
+  # shellcheck source=/dev/null
+  source "lib/functions/linterCommands.sh"
+
+  # shellcheck disable=SC2034
+  EXPECTED_LINTER_COMMANDS_ARRAY_XML=("${BASE_LINTER_COMMANDS_ARRAY_XML[@]}" "${XMLLINT_NOOUT_OPTIONS[@]}")
+
+  if ! AssertArraysElementsContentMatch "LINTER_COMMANDS_ARRAY_XML" "EXPECTED_LINTER_COMMANDS_ARRAY_XML"; then
+    fatal "${FUNCTION_NAME} test failed"
+  fi
+
+  # Restore LOG_DEBUG
+  # shellcheck disable=SC2034
+  LOG_DEBUG="true"
+
+  notice "${FUNCTION_NAME} PASS"
+}
+
 function InitFixModeOptionsAndCommandsTest() {
   local FUNCTION_NAME
   FUNCTION_NAME="${FUNCNAME[0]}"
@@ -405,3 +444,4 @@ InitFixModeOptionsAndCommandsTest
 InitPowerShellCommandTest
 CommandOptionsTest
 AddOptionsToCommandTest
+AddDebugOptionsToCommandsTest


### PR DESCRIPTION
Enables the --noout option of xmllint unless LOG_LEVEL is set to DEBUG. This avoids that xmllint emits the linted file content to stdout.

Close #6653

Credit to @thomasleplus, set as commit author.

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](../docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
