### PR TITLE
chore: dedicated ruby install stage

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,6 +31,7 @@ jobs:
           - stage-name: lintr-installer
           - stage-name: powershell-installer
           - stage-name: php-linters
+          - stage-name: ruby-installer
     timeout-minutes: 120
     env:
       CONTAINER_IMAGE_ID: "ghcr.io/super-linter/super-linter:latest"
@@ -183,6 +184,7 @@ jobs:
             type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-lintr-installer
             type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-powershell-installer
             type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-php-linters
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-ruby-installer
           load: true
           push: false
           secrets: |
@@ -222,6 +224,7 @@ jobs:
             type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-lintr-installer
             type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-powershell-installer
             type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-php-linters
+            type=registry,ref=${{ env.STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID }}-buildcache-ruby-installer
           cache-to: type=registry,ref=${{ env.CONTAINER_IMAGE_ID }}-buildcache,mode=max
           load: false
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
           - stage-name: npm-builder
           - stage-name: tflint-plugins
           - stage-name: lintr-installer
+          - stage-name: ruby-installer
           - stage-name: powershell-installer
           - stage-name: php-linters
     timeout-minutes: 120

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,7 @@ docker: docker-build-check check-github-token ## Build the container image
 		--cache-from type=registry,ref=ghcr.io/super-linter/super-linter:latest-buildcache-lintr-installer \
 		--cache-from type=registry,ref=ghcr.io/super-linter/super-linter:latest-buildcache-powershell-installer \
 		--cache-from type=registry,ref=ghcr.io/super-linter/super-linter:latest-buildcache-php-linters \
+		--cache-from type=registry,ref=ghcr.io/super-linter/super-linter:latest-buildcache-ruby-installer \
 		--secret id=GITHUB_TOKEN,src=$(GITHUB_TOKEN_PATH) \
 		--target $(IMAGE) \
 		-t $(SUPER_LINTER_TEST_CONTAINER_URL) .

--- a/dependencies/Gemfile.lock
+++ b/dependencies/Gemfile.lock
@@ -114,4 +114,4 @@ DEPENDENCIES
   standard (~> 1.42)
 
 BUNDLED WITH
-  2.5.9
+  2.5.13

--- a/lib/functions/detectFiles.sh
+++ b/lib/functions/detectFiles.sh
@@ -305,6 +305,12 @@ function RunAdditionalInstalls() {
     fatal "FILE_ARRAYS_DIRECTORY_PATH (set to ${FILE_ARRAYS_DIRECTORY_PATH}) is empty or doesn't exist"
   fi
 
+  # Run installs for Ruby
+
+  # Ref: https://bundler.io/guides/bundler_docker_guide.html
+  unset BUNDLE_PATH
+  unset BUNDLE_BIN
+
   ##################################
   # Run installs for Psalm and PHP #
   ##################################


### PR DESCRIPTION
Move ruby dependencies installation to a dedicated build stage

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
