### PR TITLE
chore: retry when cloning chktex

### DIFF
--- a/scripts/install-chktex.sh
+++ b/scripts/install-chktex.sh
@@ -11,7 +11,24 @@ apk add --no-cache --virtual .chktex-build-deps \
   libtool \
   make
 
-git clone https://git.savannah.gnu.org/git/chktex.git
+RETRIES=5
+DELAY=5
+COUNT=0
+while [ "${COUNT}" -lt "${RETRIES}" ]; do
+  if git clone https://git.savannah.gnu.org/git/chktex.git; then
+    echo "Successfully cloned the chktex Git repository"
+    RETRIES=0
+    break
+  fi
+  echo "Error while cloning the chktex Git repository."
+  ((COUNT = COUNT + 1))
+  sleep "${DELAY}"
+done
+
+if [[ ! -d "./chktex/chktex" ]]; then
+  echo "chktex directory doesn't exist."
+  exit 1
+fi
 
 cd chktex/chktex
 ./autogen.sh --prefix=/usr/bin


### PR DESCRIPTION
<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
