### PR TITLE
fix: exclude files matching default branch ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG_FILE: .gitleaks-ignore-tests.toml
-          FILTER_REGEX_EXCLUDE: ".*(/test/linters/|CHANGELOG.md).*"
+          FILTER_REGEX_EXCLUDE: ".*(/test/linters/|CHANGELOG.md|/test/data/test-repository-contents/).*"
           RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES: "default.json,hoge.json"
 
       - name: Get the contents of the log file
@@ -279,7 +279,7 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG_FILE: .gitleaks-ignore-tests.toml
-          FILTER_REGEX_EXCLUDE: ".*(/test/linters/|CHANGELOG.md).*"
+          FILTER_REGEX_EXCLUDE: ".*(/test/linters/|CHANGELOG.md|/test/data/test-repository-contents/).*"
 
   build-test-suite-matrix:
     name: Build test suite matrix

--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ test-git-flags: ## Run super-linter with different git-related flags
 		-e RUN_LOCAL=true \
 		-e LOG_LEVEL=DEBUG \
 		-e ENABLE_GITHUB_ACTIONS_GROUP_TITLE=true \
-		-e FILTER_REGEX_EXCLUDE=".*(/test/linters/|CHANGELOG.md).*" \
+		-e FILTER_REGEX_EXCLUDE=".*(/test/linters/|CHANGELOG.md|/test/data/test-repository-contents/).*" \
 		-e DEFAULT_BRANCH=main \
 		-e IGNORE_GENERATED_FILES=true \
 		-e IGNORE_GITIGNORED_FILES=true \
@@ -278,7 +278,7 @@ lint-codebase: ## Lint the entire codebase
 		-e LOG_LEVEL=DEBUG \
 		-e DEFAULT_BRANCH=main \
 		-e ENABLE_GITHUB_ACTIONS_GROUP_TITLE=true \
-		-e FILTER_REGEX_EXCLUDE=".*(/test/linters/|CHANGELOG.md).*" \
+		-e FILTER_REGEX_EXCLUDE=".*(/test/linters/|CHANGELOG.md|/test/data/test-repository-contents/).*" \
 		-e GITLEAKS_CONFIG_FILE=".gitleaks-ignore-tests.toml" \
 		-e RENOVATE_SHAREABLE_CONFIG_PRESET_FILE_NAMES="default.json,hoge.json" \
 		-e SAVE_SUPER_LINTER_OUTPUT=true \
@@ -295,7 +295,7 @@ fix-codebase: ## Fix and format the entire codebase
 		-e CREATE_LOG_FILE=true \
 		-e DEFAULT_BRANCH=main \
 		-e ENABLE_GITHUB_ACTIONS_GROUP_TITLE=true \
-		-e FILTER_REGEX_EXCLUDE=".*(/test/linters/|CHANGELOG.md).*" \
+		-e FILTER_REGEX_EXCLUDE=".*(/test/linters/|CHANGELOG.md|/test/data/test-repository-contents/).*" \
 		-e FIX_ENV=true \
 		-e FIX_JAVASCRIPT_ES=true \
 		-e FIX_JAVASCRIPT_PRETTIER=true \
@@ -331,7 +331,7 @@ lint-subset-files-enable-only-one-type: ## Lint a small subset of files in the c
 		-e LOG_LEVEL=DEBUG \
 		-e DEFAULT_BRANCH=main \
 		-e ENABLE_GITHUB_ACTIONS_GROUP_TITLE=true \
-		-e FILTER_REGEX_EXCLUDE=".*(/test/linters/|CHANGELOG.md).*" \
+		-e FILTER_REGEX_EXCLUDE=".*(/test/linters/|CHANGELOG.md|/test/data/test-repository-contents/).*" \
 		-e VALIDATE_ALL_CODEBASE=true \
 		-e VALIDATE_MARKDOWN=true \
 		-v "$(CURDIR):/tmp/lint" \
@@ -345,7 +345,7 @@ lint-subset-files-enable-expensive-io-checks: ## Lint a small subset of files in
 		-e LOG_LEVEL=DEBUG \
 		-e DEFAULT_BRANCH=main \
 		-e ENABLE_GITHUB_ACTIONS_GROUP_TITLE=true \
-		-e FILTER_REGEX_EXCLUDE=".*(/test/linters/|CHANGELOG.md).*" \
+		-e FILTER_REGEX_EXCLUDE=".*(/test/linters/|CHANGELOG.md|/test/data/test-repository-contents/).*" \
 		-e VALIDATE_ALL_CODEBASE=true \
 		-e VALIDATE_ARM=true \
 		-e VALIDATE_CLOUDFORMATION=true \

--- a/lib/functions/buildFileList.sh
+++ b/lib/functions/buildFileList.sh
@@ -16,7 +16,8 @@ function GenerateFileDiff() {
   if [[ "${GITHUB_SHA}" == "${GIT_ROOT_COMMIT_SHA}" ]]; then
     GIT_DIFF_TERM=""
     debug "Setting GIT_DIFF_TERM to an empty string because there's no commit before the initial commit to diff against."
-  elif [[ -z "${GITHUB_BEFORE_SHA:-""}" ]]; then
+  elif [[ -z "${GITHUB_BEFORE_SHA:-""}" ]] ||
+    [[ "${GITHUB_EVENT_NAME:-""}" == "pull_request" ]]; then
     GIT_DIFF_TERM="${DEFAULT_BRANCH}"
     debug "Setting GIT_DIFF_TERM to the value of DEFAULT_BRANCH because GITHUB_BEFORE_SHA was not initialized: ${GIT_DIFF_TERM}"
   else

--- a/test/data/test-repository-contents/json_bad_1.json
+++ b/test/data/test-repository-contents/json_bad_1.json
@@ -1,0 +1,14 @@
+{
+  "arrow_spacing": {
+    "level": [
+      "ignore"
+    ]
+  },
+  "foo": "bar",
+  "foo": "baz",
+  "braces_spacing": {
+    "level": 'ignore',
+    "spaces": 0,
+    "empty_object_spaces": 0
+  }
+}

--- a/test/lib/buildFileListTest.sh
+++ b/test/lib/buildFileListTest.sh
@@ -19,6 +19,7 @@ GenerateFileDiffTest() {
   local COMMITS_TO_CREATE="${2}"
   local GITHUB_EVENT_NAME="${3}"
   local SKIP_GITHUB_BEFORE_SHA_INIT="${4}"
+  local COMMIT_BAD_FILE_ON_DEFAULT_BRANCH_AND_MERGE="${5}"
 
   local TEST_FORCE_CREATE_MERGE_COMMIT
   if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
@@ -27,7 +28,7 @@ GenerateFileDiffTest() {
     TEST_FORCE_CREATE_MERGE_COMMIT="false"
   fi
 
-  initialize_git_repository_contents "${GITHUB_WORKSPACE}" "${COMMITS_TO_CREATE}" "true" "${GITHUB_EVENT_NAME}" "${TEST_FORCE_CREATE_MERGE_COMMIT}" "${SKIP_GITHUB_BEFORE_SHA_INIT}"
+  initialize_git_repository_contents "${GITHUB_WORKSPACE}" "${COMMITS_TO_CREATE}" "true" "${GITHUB_EVENT_NAME}" "${TEST_FORCE_CREATE_MERGE_COMMIT}" "${SKIP_GITHUB_BEFORE_SHA_INIT}" "${COMMIT_BAD_FILE_ON_DEFAULT_BRANCH_AND_MERGE}"
 
   # shellcheck source=/dev/null
   source "lib/functions/buildFileList.sh"
@@ -70,39 +71,44 @@ GenerateFileDiffTest() {
 }
 
 GenerateFileDiffOneFilePushEventTest() {
-  GenerateFileDiffTest "${FUNCNAME[0]}" 1 "push" "false"
+  GenerateFileDiffTest "${FUNCNAME[0]}" 1 "push" "false" "false"
 }
 GenerateFileDiffOneFilePushEventTest
 
 GenerateFileDiffTwoFilesPushEventTest() {
-  GenerateFileDiffTest "${FUNCNAME[0]}" 2 "push" "false"
+  GenerateFileDiffTest "${FUNCNAME[0]}" 2 "push" "false" "false"
 }
 GenerateFileDiffTwoFilesPushEventTest
 
 GenerateFileDiffInitialCommitPushEventTest() {
-  GenerateFileDiffTest "${FUNCNAME[0]}" 0 "push" "false"
+  GenerateFileDiffTest "${FUNCNAME[0]}" 0 "push" "false" "false"
 }
 GenerateFileDiffInitialCommitPushEventTest
 
 GenerateFileDiffPushEventNoGitHubBeforeShaTest() {
-  GenerateFileDiffTest "${FUNCNAME[0]}" 2 "push" "true"
+  GenerateFileDiffTest "${FUNCNAME[0]}" 2 "push" "true" "false"
 }
 GenerateFileDiffPushEventNoGitHubBeforeShaTest
 
 GenerateFileDiffOneFilePullRequestEventTest() {
-  GenerateFileDiffTest "${FUNCNAME[0]}" 1 "pull_request" "false"
+  GenerateFileDiffTest "${FUNCNAME[0]}" 1 "pull_request" "false" "false"
 }
 GenerateFileDiffOneFilePullRequestEventTest
 
 GenerateFileDiffTwoFilesPullRequestEventTest() {
-  GenerateFileDiffTest "${FUNCNAME[0]}" 2 "pull_request" "false"
+  GenerateFileDiffTest "${FUNCNAME[0]}" 2 "pull_request" "false" "false"
 }
 GenerateFileDiffTwoFilesPullRequestEventTest
 
 GenerateFileDiffInitialCommitPullRequestEventTest() {
-  GenerateFileDiffTest "${FUNCNAME[0]}" 0 "pull_request" "false"
+  GenerateFileDiffTest "${FUNCNAME[0]}" 0 "pull_request" "false" "false"
 }
 GenerateFileDiffTwoFilesPullRequestEventTest
+
+GenerateFileDiffMergeDefaultBranchInPullRequestBranchPullRequestEventTest() {
+  GenerateFileDiffTest "${FUNCNAME[0]}" 1 "pull_request" "false" "true"
+}
+GenerateFileDiffMergeDefaultBranchInPullRequestBranchPullRequestEventTest
 
 BuildFileArraysAnsibleGitHubWorkspaceTest() {
   local FUNCTION_NAME

--- a/test/lib/validationTest.sh
+++ b/test/lib/validationTest.sh
@@ -612,7 +612,7 @@ InitializeAndValidateGitBeforeShaReferenceMergeCommitPushTest() {
 
   local -i COMMIT_COUNT=3
 
-  initialize_git_repository_contents "${GITHUB_WORKSPACE}" "${COMMIT_COUNT}" "true" "pull_request" "true" "false"
+  initialize_git_repository_contents "${GITHUB_WORKSPACE}" "${COMMIT_COUNT}" "true" "pull_request" "true" "false" "false"
 
   local EXPECTED_GITHUB_BEFORE_SHA="${GIT_ROOT_COMMIT_SHA}"
   debug "Setting EXPECTED_GITHUB_BEFORE_SHA to ${EXPECTED_GITHUB_BEFORE_SHA}"
@@ -640,7 +640,7 @@ InitializeRootCommitShaTest() {
   GITHUB_WORKSPACE="$(mktemp -d)"
   initialize_git_repository "${GITHUB_WORKSPACE}"
 
-  initialize_git_repository_contents "${GITHUB_WORKSPACE}" 0 "false" "push" "false" "false"
+  initialize_git_repository_contents "${GITHUB_WORKSPACE}" 0 "false" "push" "false" "false" "false"
 
   local EXPECTED_GIT_ROOT_COMMIT_SHA="${GIT_ROOT_COMMIT_SHA}"
   unset GIT_ROOT_COMMIT_SHA

--- a/test/run-super-linter-tests.sh
+++ b/test/run-super-linter-tests.sh
@@ -15,7 +15,7 @@ debug "Super-linter container image type: ${SUPER_LINTER_CONTAINER_IMAGE_TYPE}"
 COMMAND_TO_RUN=(docker run --rm -t -e DEFAULT_BRANCH="${DEFAULT_BRANCH}" -e ENABLE_GITHUB_ACTIONS_GROUP_TITLE="true")
 
 ignore_test_cases() {
-  COMMAND_TO_RUN+=(-e FILTER_REGEX_EXCLUDE=".*(/test/linters/|CHANGELOG.md).*")
+  COMMAND_TO_RUN+=(-e FILTER_REGEX_EXCLUDE=".*(/test/linters/|CHANGELOG.md|/test/data/test-repository-contents/).*")
 }
 
 configure_command_arguments_for_test_git_repository() {
@@ -111,7 +111,7 @@ run_test_case_git_initial_commit() {
   GIT_REPOSITORY_PATH="$(mktemp -d)"
 
   initialize_git_repository "${GIT_REPOSITORY_PATH}"
-  initialize_git_repository_contents "${GIT_REPOSITORY_PATH}" 1 "false" "push" "false" "false"
+  initialize_git_repository_contents "${GIT_REPOSITORY_PATH}" 1 "false" "push" "false" "false" "false"
   configure_command_arguments_for_test_git_repository "${GIT_REPOSITORY_PATH}" "test/data/github-event/github-event-push.json" "push"
   initialize_github_sha "${GIT_REPOSITORY_PATH}"
 }
@@ -121,7 +121,7 @@ run_test_case_merge_commit_push() {
   GIT_REPOSITORY_PATH="$(mktemp -d)"
 
   initialize_git_repository "${GIT_REPOSITORY_PATH}"
-  initialize_git_repository_contents "${GIT_REPOSITORY_PATH}" "4" "true" "push" "true" "false"
+  initialize_git_repository_contents "${GIT_REPOSITORY_PATH}" "4" "true" "push" "true" "false" "false"
   configure_command_arguments_for_test_git_repository "${GIT_REPOSITORY_PATH}" "test/data/github-event/github-event-push-merge-commit.json" "push"
 }
 
@@ -130,7 +130,7 @@ run_test_case_github_merge_group_event() {
   GIT_REPOSITORY_PATH="$(mktemp -d)"
 
   initialize_git_repository "${GIT_REPOSITORY_PATH}"
-  initialize_git_repository_contents "${GIT_REPOSITORY_PATH}" "1" "true" "merge_group" "false" "false"
+  initialize_git_repository_contents "${GIT_REPOSITORY_PATH}" "1" "true" "merge_group" "false" "false" "false"
   configure_command_arguments_for_test_git_repository "${GIT_REPOSITORY_PATH}" "test/data/github-event/github-event-merge-group.json" "merge_group"
 }
 
@@ -139,7 +139,7 @@ run_test_case_merge_commit_push_tag() {
   GIT_REPOSITORY_PATH="$(mktemp -d)"
 
   initialize_git_repository "${GIT_REPOSITORY_PATH}"
-  initialize_git_repository_contents "${GIT_REPOSITORY_PATH}" "4" "true" "push" "true" "false"
+  initialize_git_repository_contents "${GIT_REPOSITORY_PATH}" "4" "true" "push" "true" "false" "false"
   configure_command_arguments_for_test_git_repository "${GIT_REPOSITORY_PATH}" "test/data/github-event/github-event-push-tag-merge-commit.json" "push"
   git -C "${GIT_REPOSITORY_PATH}" tag "v1.0.1-beta"
   git_log_graph "${GIT_REPOSITORY_PATH}"
@@ -153,7 +153,7 @@ configure_test_case_github_event_multiple_commits() {
   GIT_REPOSITORY_PATH="$(mktemp -d)"
 
   initialize_git_repository "${GIT_REPOSITORY_PATH}"
-  initialize_git_repository_contents "${GIT_REPOSITORY_PATH}" "${COMMITS_TO_CREATE}" "true" "${GITHUB_EVENT_NAME}" "true" "false"
+  initialize_git_repository_contents "${GIT_REPOSITORY_PATH}" "${COMMITS_TO_CREATE}" "true" "${GITHUB_EVENT_NAME}" "true" "false" "false"
   configure_command_arguments_for_test_git_repository "${GIT_REPOSITORY_PATH}" "${GITHUB_EVENT_FILE_PATH}" "${GITHUB_EVENT_NAME}"
   cp commitlint.config.js "${GIT_REPOSITORY_PATH}/"
 
@@ -221,7 +221,7 @@ run_test_case_fix_mode() {
 
   GIT_REPOSITORY_PATH="$(mktemp -d)"
   initialize_git_repository "${GIT_REPOSITORY_PATH}"
-  initialize_git_repository_contents "${GIT_REPOSITORY_PATH}" 1 "false" "push" "false" "false"
+  initialize_git_repository_contents "${GIT_REPOSITORY_PATH}" 1 "false" "push" "false" "false" "false"
   configure_command_arguments_for_test_git_repository "${GIT_REPOSITORY_PATH}" "test/data/github-event/github-event-push.json" "push"
 
   # Remove leftovers before copying test files because other tests might have


### PR DESCRIPTION
When linting a GitHub pull request, exclude files that don't change compared to the default branch.

Fix #6798

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
