### PR TITLE
chore: disable errexit when getting versions

### DIFF
--- a/scripts/linterVersions.sh
+++ b/scripts/linterVersions.sh
@@ -116,6 +116,9 @@ for LANGUAGE in "${!LINTER_NAMES_ARRAY[@]}"; do
   LINTER="${LINTER_NAMES_ARRAY[${LANGUAGE}]}"
   echo "Get version for ${LINTER}"
 
+  # Disable errexit because we want to get the error output
+  set +o errexit
+
   # Some linters need to account for special commands to get their version instead
   # of the default --version option
 
@@ -231,6 +234,9 @@ for LANGUAGE in "${!LINTER_NAMES_ARRAY[@]}"; do
   fi
 
   ERROR_CODE=$?
+  # Enable errexit back
+  set -o errexit
+
   if [ ${ERROR_CODE} -ne 0 ]; then
     echo "[ERROR]: Failed to get version info for ${LINTER}. Exit code: ${ERROR_CODE}. Output: ${GET_VERSION_CMD}"
     exit 1


### PR DESCRIPTION
Disable errexit when running the command to get the version of a linter or formatter, and enable errexit again after running that command. This allows the following error check to work as intended, and emit error messages.

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
