### PR TITLE
docs: add git worktrees section to local run documentation

### DIFF
--- a/docs/run-linter-locally.md
+++ b/docs/run-linter-locally.md
@@ -71,7 +71,7 @@ git rev-parse --path-format=absolute --git-common-dir
 
 This will output the absolute path to the main Git directory, for example:
 
-```
+```bash
 /path/to/main/repo/.git
 ```
 

--- a/docs/run-linter-locally.md
+++ b/docs/run-linter-locally.md
@@ -83,8 +83,10 @@ If you forget to mount the main Git directory, super-linter will detect this and
 provide a helpful error message indicating exactly which directory needs to be
 mounted:
 
-```
-Detected a git worktree at /tmp/lint, but git cannot operate. Please mount the main git directory located at: /path/to/main/repo/.git
+```text
+/path/to/main/repo/.git/worktrees/my-worktree doesn't exist.
+Ensure to mount it as a volume when running the Super-linter container.
+See https://github.com/super-linter/super-linter/blob/main/docs/run-linter-locally.md
 ```
 
 ### GitLab

--- a/docs/run-linter-locally.md
+++ b/docs/run-linter-locally.md
@@ -37,6 +37,47 @@ Notes:
 - You can add as many configuration options as needed. Configuration options are
   documented in the [readme](../README.md#configure-super-linter).
 
+### Working with Git Worktrees
+
+Git worktrees allow you to have multiple working directories associated with a single git repository, which is useful for working on different branches simultaneously without switching contexts.
+
+When running super-linter in a git worktree, you must mount both the worktree directory and the main git repository directory into the container. This is because worktrees store only the working files, while git metadata remains in the main repository's `.git` directory.
+
+#### Example Docker Command for Git Worktrees
+
+```bash
+docker run \
+  -e LOG_LEVEL=DEBUG \
+  -e RUN_LOCAL=true \
+  -v /path/to/your/worktree:/tmp/lint \
+  -v /path/to/main/repo/.git:/path/to/main/repo/.git \
+  --rm \
+  ghcr.io/super-linter/super-linter:latest
+```
+
+#### Finding Your Git Common Directory
+
+To find the main git directory that needs to be mounted, use the following git command from within your worktree:
+
+```bash
+git rev-parse --path-format=absolute --git-common-dir
+```
+
+This will output the absolute path to the main git directory, for example:
+```
+/path/to/main/repo/.git
+```
+
+Use this output as the source path for your Docker volume mount.
+
+#### Helpful Error Messages
+
+If you forget to mount the main git directory, super-linter will detect this and provide a helpful error message indicating exactly which directory needs to be mounted:
+
+```
+Detected a git worktree at /tmp/lint, but git cannot operate. Please mount the main git directory located at: /path/to/main/repo/.git
+```
+
 ### GitLab
 
 To run Super-linter in your GitLab CI/CD pipeline, You can use the following

--- a/docs/run-linter-locally.md
+++ b/docs/run-linter-locally.md
@@ -39,9 +39,14 @@ Notes:
 
 ### Working with Git Worktrees
 
-Git worktrees allow you to have multiple working directories associated with a single git repository, which is useful for working on different branches simultaneously without switching contexts.
+Git worktrees allow you to have multiple working directories associated with a
+single Git repository, which is useful for working on different branches
+simultaneously without switching contexts.
 
-When running super-linter in a git worktree, you must mount both the worktree directory and the main git repository directory into the container. This is because worktrees store only the working files, while git metadata remains in the main repository's `.git` directory.
+When running super-linter in a Git worktree, you must mount both the worktree
+directory and the main Git repository directory into the container. This is
+because worktrees store only the working files, while Git metadata remains in
+the main repository's `.git` directory.
 
 #### Example Docker Command for Git Worktrees
 
@@ -57,13 +62,15 @@ docker run \
 
 #### Finding Your Git Common Directory
 
-To find the main git directory that needs to be mounted, use the following git command from within your worktree:
+To find the main Git directory that needs to be mounted, use the following Git
+command from within your worktree:
 
 ```bash
 git rev-parse --path-format=absolute --git-common-dir
 ```
 
-This will output the absolute path to the main git directory, for example:
+This will output the absolute path to the main Git directory, for example:
+
 ```
 /path/to/main/repo/.git
 ```
@@ -72,7 +79,9 @@ Use this output as the source path for your Docker volume mount.
 
 #### Helpful Error Messages
 
-If you forget to mount the main git directory, super-linter will detect this and provide a helpful error message indicating exactly which directory needs to be mounted:
+If you forget to mount the main Git directory, super-linter will detect this and
+provide a helpful error message indicating exactly which directory needs to be
+mounted:
 
 ```
 Detected a git worktree at /tmp/lint, but git cannot operate. Please mount the main git directory located at: /path/to/main/repo/.git


### PR DESCRIPTION
Add comprehensive documentation for running super-linter with git worktrees, including Docker mount requirements and git commands for finding the common directory. This comes in addition to #6983 while addressing #6944.

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [ ] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
