### PR TITLE
docs: upgrade actions/checkout from v4 to v5 and fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ To run super-linter as a GitHub Action, you do the following:
 
        steps:
          - name: Checkout code
-           uses: actions/checkout@v4
+           uses: actions/checkout@v5
            with:
              # super-linter needs the full git history to get the
              # list of files that changed across commits
@@ -542,7 +542,7 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Super-Linter
@@ -573,13 +573,13 @@ jobs:
 
 This example uses
 [GitHub Actions automatic token authentication](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication)
-that automatically greates a unique `GITHUB_TOKEN` secret for the workflow.
+that automatically creates a unique `GITHUB_TOKEN` secret for the workflow.
 GitHub Actions imposes the following limitations on workflows:
 
 - To avoid accidentally creating recursive workflow runs, the commit that
   contains linting and formatting fixes
   [doesn't create new workflow runs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
-- It restrict edits to GitHub Actions workflows files (in `.github/workflows`).
+- It restricts edits to GitHub Actions workflows files (in `.github/workflows`).
 - It may fail pushing commits to protected branches.
 
 To work around these limitations, you do the following:
@@ -590,7 +590,7 @@ To work around these limitations, you do the following:
 1. Use the authentication token in the `actions/checkout` step:
 
    ```yaml
-   - uses: actions/checkout@v4
+   - uses: actions/checkout@v5
      with:
        fetch-depth: 0
        token: ${{ secrets.SUPER_LINTER_TOKEN }}


### PR DESCRIPTION
<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [ ] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [ ] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [ ] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
