### PR TITLE
chore: simplify more tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,6 @@ test: \
 	test-log-level \
 	test-use-find-and-ignore-gitignored-files \
 	test-linters-expect-failure-log-level-notice \
-	test-bash-exec-library-expect-success \
-	test-bash-exec-library-expect-failure \
 	test-save-super-linter-output \
 	test-save-super-linter-output-custom-path \
 	test-save-super-linter-custom-summary \
@@ -320,7 +318,8 @@ test-lib: \
 	test-output \
 	test-linter-commands \
 	test-linter-versions \
-	test-update-ssl
+	test-update-ssl \
+	test-bash-exec
 
 .PHONY: test-log
 test-log: ## Test log initialization and functions
@@ -440,6 +439,15 @@ test-update-ssl: ## Test updateSSL
 		--rm \
 		$(SUPER_LINTER_TEST_CONTAINER_URL)
 
+.PHONY: test-bash-exec
+test-bash-exec: ## Test bash-exec
+	docker run \
+		-v "$(CURDIR):/tmp/lint" \
+		-w /tmp/lint \
+		--entrypoint /tmp/lint/test/lib/bashExecTest.sh \
+		--rm \
+		$(SUPER_LINTER_TEST_CONTAINER_URL)
+
 .PHONY: test-runtime-dependencies-installation ## Test runtime dependencies installation
 test-runtime-dependencies-installation: \
 	test-os-packages-installation
@@ -516,20 +524,6 @@ test-linters-expect-failure-log-level-notice: ## Run the linters test suite expe
 	$(CURDIR)/test/run-super-linter-tests.sh \
 		$(SUPER_LINTER_TEST_CONTAINER_URL) \
 		"run_test_cases_expect_failure_notice_log" \
-		"$(IMAGE)"
-
-.PHONY: test-bash-exec-library-expect-success
-test-bash-exec-library-expect-success: ## Run the linters test cases for BASH_EXEC expecting successes with BASH_EXEC_IGNORE_LIBRARIES set to true
-	$(CURDIR)/test/run-super-linter-tests.sh \
-		$(SUPER_LINTER_TEST_CONTAINER_URL) \
-		"run_test_case_bash_exec_library_expect_success" \
-		"$(IMAGE)"
-
-.PHONY: test-bash-exec-library-expect-failure
-test-bash-exec-library-expect-failure: ## Run the linters test cases for BASH_EXEC expecting failures with BASH_EXEC_IGNORE_LIBRARIES set to true
-	$(CURDIR)/test/run-super-linter-tests.sh \
-		$(SUPER_LINTER_TEST_CONTAINER_URL) \
-		"run_test_case_bash_exec_library_expect_failure" \
 		"$(IMAGE)"
 
 .PHONY: test-git-initial-commit

--- a/test/lib/bashExecTest.sh
+++ b/test/lib/bashExecTest.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# shellcheck source=/dev/null
+source "test/testUtils.sh"
+
+# shellcheck source=/dev/null
+source "lib/functions/detectFiles.sh"
+
+BashExecIgnoreLibrariesTest() {
+  local FUNCTION_NAME
+  FUNCTION_NAME="${FUNCNAME[0]}"
+  info "${FUNCTION_NAME} start"
+
+  local TEST_FILE_PATH="test/linters/bash_exec/libraries/noShebang_bad.sh"
+
+  if scripts/bash-exec.sh "${TEST_FILE_PATH}"; then
+    fatal "bash-exec without any option should have failed"
+  fi
+
+  if scripts/bash-exec.sh "${TEST_FILE_PATH}" "false"; then
+    fatal "bash-exec with 'false' should have failed"
+  fi
+
+  if ! scripts/bash-exec.sh "${TEST_FILE_PATH}" "true"; then
+    fatal "bash-exec with 'false' should not have failed"
+  fi
+
+  notice "${FUNCTION_NAME} PASS"
+}
+
+BashExecIgnoreLibrariesTest

--- a/test/lib/buildFileListTest.sh
+++ b/test/lib/buildFileListTest.sh
@@ -116,9 +116,9 @@ BuildFileArraysAnsibleGitHubWorkspaceTest() {
   info "${FUNCTION_NAME} start"
 
   # shellcheck source=/dev/null
-  source /action/lib/functions/detectFiles.sh
+  source "lib/functions/detectFiles.sh"
   # shellcheck source=/dev/null
-  source /action/lib/functions/validation.sh
+  source "lib/functions/validation.sh"
 
   # shellcheck disable=SC2034
   local FILTER_REGEX_INCLUDE=""

--- a/test/lib/linterCommandsTest.sh
+++ b/test/lib/linterCommandsTest.sh
@@ -42,7 +42,7 @@ ValidateValidationVariables
 # Now we can load linter command options because they have
 # dependencies on linter rules
 # shellcheck source=/dev/null
-source /action/lib/globals/linterCommandsOptions.sh
+source lib/globals/linterCommandsOptions.sh
 
 # The slim image might not have this variable defined
 if [[ ! -v ARM_TTK_PSD1 ]]; then
@@ -59,6 +59,7 @@ source "lib/functions/linterCommands.sh"
 # Initialize the variables we're going to use to verify tests before running tests
 # because some tests modify LINTER_COMMANDS_xxx variables
 BASE_LINTER_COMMANDS_ARRAY_ANSIBLE=("${LINTER_COMMANDS_ARRAY_ANSIBLE[@]}")
+BASE_LINTER_COMMANDS_ARRAY_BASH_EXEC=("${LINTER_COMMANDS_ARRAY_BASH_EXEC[@]}")
 BASE_LINTER_COMMANDS_ARRAY_GITHUB_ACTIONS=("${LINTER_COMMANDS_ARRAY_GITHUB_ACTIONS[@]}")
 BASE_LINTER_COMMANDS_ARRAY_GIT_COMMITLINT=("${LINTER_COMMANDS_ARRAY_GIT_COMMITLINT[@]}")
 BASE_LINTER_COMMANDS_ARRAY_GITLEAKS=("${LINTER_COMMANDS_ARRAY_GITLEAKS[@]}")
@@ -389,6 +390,28 @@ function InitPowerShellCommandTest() {
   notice "${FUNCTION_NAME} PASS"
 }
 
+BashExecIgnoreLibrariesTest() {
+  local FUNCTION_NAME
+  FUNCTION_NAME="${FUNCNAME[0]}"
+  info "${FUNCTION_NAME} start"
+
+  # shellcheck disable=SC2034
+  local BASH_EXEC_IGNORE_LIBRARIES="true"
+
+  # shellcheck disable=SC2034
+  local EXPECTED_LINTER_COMMANDS_ARRAY_BASH_EXEC=("${BASE_LINTER_COMMANDS_ARRAY_BASH_EXEC[@]}" "true")
+
+  # Source the file again so it accounts for modifications
+  # shellcheck source=/dev/null
+  source "lib/functions/linterCommands.sh"
+
+  if ! AssertArraysElementsContentMatch "LINTER_COMMANDS_ARRAY_BASH_EXEC" "EXPECTED_LINTER_COMMANDS_ARRAY_BASH_EXEC"; then
+    fatal "${FUNCTION_NAME} test failed"
+  fi
+
+  notice "${FUNCTION_NAME} PASS"
+}
+
 # Test environment variables to set command options
 CommandOptionsTest() {
   local FUNCTION_NAME
@@ -506,6 +529,7 @@ GitleaksCommandCustomLogLevelTest
 InitInputConsumeCommandsTest
 InitFixModeOptionsAndCommandsTest
 InitPowerShellCommandTest
+BashExecIgnoreLibrariesTest
 CommandOptionsTest
 AddOptionsToCommandTest
 AddDebugOptionsToCommandsTest

--- a/test/lib/osPackagesInstallationTest.sh
+++ b/test/lib/osPackagesInstallationTest.sh
@@ -11,7 +11,7 @@ source "test/testUtils.sh"
 source "lib/functions/runtimeDependencies.sh"
 
 # shellcheck source=/dev/null
-source /action/lib/globals/runtimeDependencies.sh
+source lib/globals/runtimeDependencies.sh
 
 InstallOsPackagesTest() {
   local FUNCTION_NAME

--- a/test/run-super-linter-tests.sh
+++ b/test/run-super-linter-tests.sh
@@ -90,16 +90,6 @@ run_test_cases_non_default_home() {
   COMMAND_TO_RUN+=(-e HOME=/tmp)
 }
 
-run_test_case_bash_exec_library_expect_failure() {
-  run_test_cases_expect_failure
-  COMMAND_TO_RUN+=(-e BASH_EXEC_IGNORE_LIBRARIES="true")
-}
-
-run_test_case_bash_exec_library_expect_success() {
-  run_test_cases_expect_success
-  COMMAND_TO_RUN+=(-e BASH_EXEC_IGNORE_LIBRARIES="true")
-}
-
 run_test_case_dont_save_super_linter_log_file() {
   run_test_cases_expect_success
   CREATE_LOG_FILE="false"


### PR DESCRIPTION
- Implement bash-exec tests instead of just running a smoke test
- Source libs from mounted files when testing functions so we don't need to rebuild the container image on each change

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
