### PR TITLE
fix: initialize GITHUB_BEFORE_SHA on merge commits

### DIFF
--- a/lib/functions/githubEvent.sh
+++ b/lib/functions/githubEvent.sh
@@ -51,7 +51,8 @@ function GetGithubRepositoryDefaultBranch() {
   GITHUB_REPOSITORY_DEFAULT_BRANCH=$(jq -r '.repository.default_branch' <"${GITHUB_EVENT_FILE_PATH}")
   local RET_CODE=$?
   if [[ "${RET_CODE}" -gt 0 ]]; then
-    fatal "Failed to initialize GITHUB_REPOSITORY_DEFAULT_BRANCH. Output: ${GITHUB_REPOSITORY_DEFAULT_BRANCH}"
+    error "Failed to initialize GITHUB_REPOSITORY_DEFAULT_BRANCH. Output: ${GITHUB_REPOSITORY_DEFAULT_BRANCH}"
+    return 1
   fi
 
   echo "${GITHUB_REPOSITORY_DEFAULT_BRANCH}"

--- a/test/lib/githubEventTest.sh
+++ b/test/lib/githubEventTest.sh
@@ -66,7 +66,9 @@ function GetGithubRepositoryDefaultBranchTest() {
   info "${FUNCTION_NAME} start"
 
   local GITHUB_REPOSITORY_DEFAULT_BRANCH
-  GITHUB_REPOSITORY_DEFAULT_BRANCH=$(GetGithubRepositoryDefaultBranch "test/data/github-event/github-event-push.json")
+  if ! GITHUB_REPOSITORY_DEFAULT_BRANCH=$(GetGithubRepositoryDefaultBranch "test/data/github-event/github-event-push.json"); then
+    fatal "Error while setting GITHUB_REPOSITORY_DEFAULT_BRANCH"
+  fi
 
   debug "GITHUB_REPOSITORY_DEFAULT_BRANCH: ${GITHUB_REPOSITORY_DEFAULT_BRANCH}"
 

--- a/test/testUtils.sh
+++ b/test/testUtils.sh
@@ -40,6 +40,9 @@ TEST_ROOT_CA_CERT_FILE_PATH="test/data/ssl-certificate/rootCA-test.crt"
 # Set an arbitrary pull request name
 PULL_REQUEST_BRANCH_NAME="pull/6637/merge"
 
+# Set an arbitrary new branch name
+NEW_BRANCH_NAME="branch-1"
+
 # TODO: use TEST_CASE_FOLDER instead of redefining this after we extract the
 # initialization of TEST_CASE_FOLDER from linter.sh
 # shellcheck disable=SC2034
@@ -259,7 +262,7 @@ initialize_git_repository() {
     mkdir --parents "${GIT_REPOSITORY_PATH}"
   fi
 
-  debug "GIT_REPOSITORY_PATH: ${GIT_REPOSITORY_PATH}"
+  debug "GIT_REPOSITORY_PATH: ${GIT_REPOSITORY_PATH}. DEFAULT_BRANCH: ${DEFAULT_BRANCH}"
 
   git -C "${GIT_REPOSITORY_PATH}" init --initial-branch="${DEFAULT_BRANCH:-"main"}"
   git -C "${GIT_REPOSITORY_PATH}" config user.name "Super-linter Test"
@@ -293,8 +296,6 @@ initialize_git_repository_contents() {
   local SKIP_GITHUB_BEFORE_SHA_INIT="${1}" && shift
   local COMMIT_BAD_FILE_ON_DEFAULT_BRANCH_AND_MERGE="${1}" && shift
   local INITIALIZE_GITHUB_SHA="${1}" && shift
-
-  local NEW_BRANCH_NAME="branch-1"
 
   debug "Creating the initial commit"
   local TEST_FILE_PATH


### PR DESCRIPTION
- Handle initializing GITHUB_BEFORE_SHA on merge commits on pull_request
  events by checking to which commit the DEFAULT_BRANCH is pointing at.
- Move the GIT_BEFORE_SHA validation logic in the
  ValidateGitShaReference function.
- Move DEFAULT_BRANCH initialization before the GITHUB_BEFORE_SHA
  initialization because the default branch might be needed to
  initialize GITHUB_BEFORE_SHA.
- Move GITHUB_WORKSPACE initialization and validation logic in the
  InitializeGitHubWorkspace function.
- Move GITHUB_WORKSPACE initialization before the initialization of the
  DEFAULT_BRANCH variable.

Fix #6873

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
