### PR TITLE
fix: handle schedule and workflow_dispatch events

### DIFF
--- a/lib/functions/validation.sh
+++ b/lib/functions/validation.sh
@@ -381,8 +381,12 @@ InitializeGitBeforeShaReference() {
     GIT_BEFORE_SHA_HEAD="${GIT_BEFORE_SHA_HEAD}~${GITHUB_EVENT_COMMIT_COUNT}"
   elif [[ "${GITHUB_EVENT_NAME}" == "merge_group" ]] ||
     [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] ||
-    [[ "${GITHUB_EVENT_NAME}" == "pull_request_target" ]]; then
+    [[ "${GITHUB_EVENT_NAME}" == "pull_request_target" ]] ||
+    [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
     GIT_BEFORE_SHA_HEAD="${DEFAULT_BRANCH}"
+  else
+    error "GitHub event not supported: ${GITHUB_EVENT_NAME}"
+    return 1
   fi
 
   debug "GIT_BEFORE_SHA_HEAD: ${GIT_BEFORE_SHA_HEAD}"

--- a/test/lib/validationTest.sh
+++ b/test/lib/validationTest.sh
@@ -614,10 +614,13 @@ InitializeGitBeforeShaReferenceMergeCommitTest() {
   local -i COMMIT_COUNT=3
 
   if [[ "${EVENT_NAME}" == "pull_request" ]] ||
-    [[ "${EVENT_NAME}" == "pull_request_target" ]]; then
+    [[ "${EVENT_NAME}" == "pull_request_target" ]] ||
+    [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
     initialize_git_repository_contents "${GITHUB_WORKSPACE}" "${COMMIT_COUNT}" "true" "${EVENT_NAME}" "true" "false" "false" "true"
   elif [[ "${EVENT_NAME}" == "merge_group" ]]; then
     initialize_git_repository_contents "${GITHUB_WORKSPACE}" "${COMMIT_COUNT}" "true" "${EVENT_NAME}" "false" "false" "false" "true"
+  else
+    fatal "Event not handled: ${EVENT_NAME}"
   fi
   local EXPECTED_GITHUB_BEFORE_SHA="${GIT_ROOT_COMMIT_SHA}"
   debug "Setting EXPECTED_GITHUB_BEFORE_SHA to ${EXPECTED_GITHUB_BEFORE_SHA}"
@@ -660,6 +663,26 @@ InitializeGitBeforeShaReferenceMergeCommitMergeGroupTest() {
   info "${FUNCTION_NAME} start"
 
   InitializeGitBeforeShaReferenceMergeCommitTest "merge_group"
+
+  notice "${FUNCTION_NAME} PASS"
+}
+
+InitializeGitBeforeShaReferenceMergeCommitScheduleTest() {
+  local FUNCTION_NAME
+  FUNCTION_NAME="${FUNCNAME[0]}"
+  info "${FUNCTION_NAME} start"
+
+  InitializeGitBeforeShaReferenceMergeCommitTest "schedule"
+
+  notice "${FUNCTION_NAME} PASS"
+}
+
+InitializeGitBeforeShaReferenceMergeCommitWorkflowDispatchTest() {
+  local FUNCTION_NAME
+  FUNCTION_NAME="${FUNCNAME[0]}"
+  info "${FUNCTION_NAME} start"
+
+  InitializeGitBeforeShaReferenceMergeCommitTest "workflow_dispatch"
 
   notice "${FUNCTION_NAME} PASS"
 }
@@ -1020,6 +1043,8 @@ InitializeGitBeforeShaReferenceFastForwardPushTest
 InitializeGitBeforeShaReferenceMergeCommitPullRequestTest
 InitializeGitBeforeShaReferenceMergeCommitPullRequestTargetGroupTest
 InitializeGitBeforeShaReferenceMergeCommitMergeGroupTest
+InitializeGitBeforeShaReferenceMergeCommitScheduleTest
+InitializeGitBeforeShaReferenceMergeCommitWorkflowDispatchTest
 InitializeGitBeforeShaReferenceMergeDefaultBranchInPullRequestBranchTest
 ValidateGitShaReferenceTest
 InitializeRootCommitShaTest

--- a/test/testUtils.sh
+++ b/test/testUtils.sh
@@ -335,7 +335,8 @@ initialize_git_repository_contents() {
   debug "Simulating a GitHub ${GITHUB_EVENT_NAME:-"not set"} event"
 
   if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] ||
-    [[ "${GITHUB_EVENT_NAME}" == "pull_request_target" ]]; then
+    [[ "${GITHUB_EVENT_NAME}" == "pull_request_target" ]] ||
+    [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
     debug "Switching to the ${DEFAULT_BRANCH} branch"
     git -C "${GIT_REPOSITORY_PATH}" switch "${DEFAULT_BRANCH}"
 


### PR DESCRIPTION
Handle schedule and workflow_dispatch events when initializing InitializeGitBeforeShaReference.

Fix #7095

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
