### PR TITLE
feat: powershell ansi output and dynamic sizing

### DIFF
--- a/lib/functions/worker.sh
+++ b/lib/functions/worker.sh
@@ -205,7 +205,7 @@ function LintCodebase() {
   if [[ "${FILE_TYPE}" == "ARM" ]] ||
     [[ "${FILE_TYPE}" == "POWERSHELL" ]]; then
     # Run as a Powershell command
-    LINTER_COMMAND_ARRAY=(pwsh -NoProfile -NoLogo -Command "\"${LINTER_COMMAND_ARRAY[*]}; if (\\\${Error}.Count) { exit 1 }\"")
+    LINTER_COMMAND_ARRAY=(pwsh -NoProfile -NoLogo -Command "\"\\\$PSStyle.OutputRendering = 'Ansi'; ${LINTER_COMMAND_ARRAY[*]} | Out-String; if (\\\${Error}.Count) { exit 1 }\"")
   fi
 
   debug "LINTER_COMMAND_ARRAY for ${FILE_TYPE} has ${#LINTER_COMMAND_ARRAY[@]} elements after initializing command arguments: ${LINTER_COMMAND_ARRAY[*]}"


### PR DESCRIPTION
Set $PSStyle.OutputRendering to Ansi and pipe output to Out-String to enable dynamic host sizing and better readability.

Close #7445

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
