### PR TITLE
chore: add format targets

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+# Generated files
+CHANGELOG.md
+
+# Some test files have linting errors, on purpose
+test/linters/**/*bad*
+test/linters/**/*bad*/**

--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,22 @@ fix-codebase: ## Fix and format the entire codebase
 		"fix_codebase" \
 		"$(IMAGE)"
 
+.PHONY: format-codebase ## Format the codebase
+format-codebase: \
+	format-prettier
+
+FILES_TO_FORMAT ?= .
+
+.PHONY: format-prettier
+format-prettier: ## Run prettier to format the codebase
+	docker run $(DOCKER_FLAGS) \
+		--entrypoint /bin/bash \
+		--rm \
+		-v "$(CURDIR):/tmp/lint" \
+		--workdir "/tmp/lint" \
+		$(SUPER_LINTER_TEST_CONTAINER_URL) \
+		-c "prettier --write $(FILES_TO_FORMAT)"
+
 # This is a smoke test to check how much time it takes to lint only a small
 # subset of files, compared to linting the whole codebase.
 .PHONY: lint-subset-files

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -49,6 +49,16 @@ the most important targets:
 - `make lint-codebase`: Runs a comprehensive set of linters against the entire
   codebase to check for style and formatting issues.
 - `make fix-codebase`: Automatically fixes linting and formatting issues.
+- `make format-codebase`: Runs all formatter targets (such as Prettier) to
+  format files in the repository.
+- `make format-prettier`: Runs Prettier to format the codebase. You can format
+  specific files or directories in isolation by passing the `FILES_TO_FORMAT`
+  variable:
+
+  ```bash
+  make format-prettier FILES_TO_FORMAT="test/linters/html/html_good_01.html"
+  ```
+
 - `make test`: Runs the complete test suite. To run a specific subset of tests,
   you can use `make help` to find the relevant targets.
 - `make open-shell-super-linter-container`: Opens an interactive shell in the


### PR DESCRIPTION
- Add .prettierignore to ignore malformed lint test files under test/linters.
- Enhance Makefile format-prettier target to support FILES_TO_FORMAT for isolated Prettier runs, and add format-codebase target.
- Update docs/DEVELOPMENT.md to document new format make targets.

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
