### PR TITLE
fix: ktlint installation

### DIFF
--- a/scripts/install-ktlint.sh
+++ b/scripts/install-ktlint.sh
@@ -8,14 +8,22 @@ KTLINT_VERSION="$(
 )"
 echo "Installing Ktlint: ${KTLINT_VERSION}"
 
-url=$(
+ktlint_tags=$(
   set -euo pipefail
   curl -s \
     -H "Accept: application/vnd.github+json" \
     -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \
-    "https://api.github.com/repos/pinterest/ktlint/releases/tags/${KTLINT_VERSION}" |
-    jq -r '.assets | .[] | select(.name=="ktlint") | .url'
+    "https://api.github.com/repos/ktlint/ktlint/releases/tags/${KTLINT_VERSION}"
 )
+
+echo "ktlint tags: ${ktlint_tags}"
+
+url=$(
+  set -euo pipefail
+  jq -r '.assets | .[] | select(.name=="ktlint") | .url' <<<"${ktlint_tags}"
+)
+echo "ktlint asset URL: ${url}"
+
 curl --retry 5 --retry-delay 5 -sL -o "/usr/bin/ktlint" \
   -H "Accept: application/octet-stream" \
   -H "Authorization: Bearer $(cat /run/secrets/GITHUB_TOKEN)" \


### PR DESCRIPTION
Update ktlint repository to ktlint/ktlint

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
