### PR TITLE
fix: terragrunt version lookup

### DIFF
--- a/scripts/linterVersions.sh
+++ b/scripts/linterVersions.sh
@@ -231,7 +231,7 @@ for LANGUAGE in "${!LINTER_NAMES_ARRAY[@]}"; do
   elif [[ ${LINTER} == "terraform" ]]; then
     GET_VERSION_CMD="$("${LINTER}" version -json | jq --raw-output .terraform_version)"
   elif [[ "${LINTER}" == "terragrunt" ]]; then
-    GET_VERSION_CMD="$("${LINTER}" --version | awk '{ print $3 }' | sed 's/^v//')"
+    GET_VERSION_CMD="$("${LINTER}" --version | awk '{ print $3 }')"
   elif [[ ${LINTER} == "tflint" ]]; then
     # Unset TF_LOG_LEVEL so that the version file doesn't contain debug log when running
     # commands that read TF_LOG_LEVEL or TFLINT_LOG, which are likely set to DEBUG when

--- a/scripts/linterVersions.sh
+++ b/scripts/linterVersions.sh
@@ -231,7 +231,7 @@ for LANGUAGE in "${!LINTER_NAMES_ARRAY[@]}"; do
   elif [[ ${LINTER} == "terraform" ]]; then
     GET_VERSION_CMD="$("${LINTER}" version -json | jq --raw-output .terraform_version)"
   elif [[ "${LINTER}" == "terragrunt" ]]; then
-    GET_VERSION_CMD="$("${LINTER}" --version | awk '{ print $2 }')"
+    GET_VERSION_CMD="$("${LINTER}" --version | awk '{ print $3 }' | sed 's/^v//')"
   elif [[ ${LINTER} == "tflint" ]]; then
     # Unset TF_LOG_LEVEL so that the version file doesn't contain debug log when running
     # commands that read TF_LOG_LEVEL or TFLINT_LOG, which are likely set to DEBUG when


### PR DESCRIPTION
Fix terragrunt version lookup in `linterVersion.sh`

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [X] I checked that all workflows return a success.
- [X] I included all the needed documentation for this change.
- [X] I provided the necessary tests.
- [X] I squashed all the commits into a single commit.
- [X] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I wrote the necessary upgrade instructions in the
      [upgrade guide](https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md).
- [X] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
