### PR TITLE
chore: audit workflow, format shell scripts

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,0 +1,54 @@
+name: Dependency Audits
+
+on:
+  workflow_call:
+  schedule:
+    # Fire every Monday at 04:00 UTC
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+  # Trigger on pushes to any branch except main, because main pushes already trigger
+  # the Publish Images workflow, which we monitor via the workflow_call event above.
+  push:
+    branches-ignore:
+      - main
+  pull_request:
+
+# Don't grant any access by default
+permissions: {}
+
+jobs:
+  audit:
+    name: Dependency Audits
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-${{ github.event_name }}-audit-${{ matrix.package-ecosystems.target }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      issues: write
+    strategy:
+      fail-fast: false
+      # Run on the standard image only, assuming that it contains all the packages of the slim version
+      matrix:
+        package-ecosystems:
+          - name: composer
+            target: composer-audit
+          - name: npm
+            target: npm-audit
+          - name: pip
+            target: pip-audit
+    timeout-minutes: 120
+    env:
+      CONTAINER_IMAGE_TARGET: standard
+      STAGES_BUILD_CACHE_CONTAINER_IMAGE_ID: "ghcr.io/super-linter/super-linter:latest"
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Run Audits (${{ matrix.package-ecosystems.name }})
+        run: make ${{ matrix.package-ecosystems.target }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -368,3 +368,12 @@ jobs:
                 "zkoppert", "Hanse00", "ferrarimarco"
               ]
             })
+
+  trigger-audit:
+    name: Trigger Dependency Audits
+    needs:
+      - test
+    uses: ./.github/workflows/audit.yaml
+    permissions:
+      contents: read
+      issues: write

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,6 @@ test: \
 	validate-container-image-labels \
 	docker-build-check \
 	docker-dev-container-build-check \
-	composer-audit \
-	npm-audit \
-	pip-audit \
 	test-lib \
 	inspec \
 	lint-codebase \
@@ -49,6 +46,12 @@ test: \
 	test-linters-expect-success-suppress-output-on-success \
 	test-linters-expect-success-suppress-output-on-success-log-level-notice \
 	test-linters-fix-mode
+
+.PHONY: audit ## Run dependency audits
+audit: \
+	composer-audit \
+	npm-audit \
+	pip-audit
 
 SHELL := /bin/bash
 
@@ -282,7 +285,8 @@ fix-codebase: ## Fix and format the entire codebase
 
 .PHONY: format-codebase ## Format the codebase
 format-codebase: \
-	format-prettier
+	format-prettier \
+	format-shfmt
 
 FILES_TO_FORMAT ?= .
 
@@ -295,6 +299,16 @@ format-prettier: ## Run prettier to format the codebase
 		--workdir "/tmp/lint" \
 		$(SUPER_LINTER_TEST_CONTAINER_URL) \
 		-c "prettier --write $(FILES_TO_FORMAT) '!test/linters/**/*bad*' '!test/linters/**/*bad*/**'"
+
+.PHONY: format-shfmt
+format-shfmt: ## Run shfmt to format shell scripts in the codebase
+	docker run $(DOCKER_FLAGS) \
+		--entrypoint /bin/bash \
+		--rm \
+		-v "$(CURDIR):/tmp/lint" \
+		--workdir "/tmp/lint" \
+		$(SUPER_LINTER_TEST_CONTAINER_URL) \
+		-c "shfmt --write $(FILES_TO_FORMAT)"
 
 # This is a smoke test to check how much time it takes to lint only a small
 # subset of files, compared to linting the whole codebase.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -48,6 +48,10 @@ the most important targets:
 
 - `make lint-codebase`: Runs a comprehensive set of linters against the entire
   codebase to check for style and formatting issues.
+- `make audit`: Runs all security audit targets (`composer-audit`, `npm-audit`,
+  `pip-audit`) to check for known vulnerabilities in downstream dependencies and
+  container filesystems. You can also execute each target in isolation (e.g.,
+  `make npm-audit`).
 - `make fix-codebase`: Automatically fixes linting and formatting issues.
 - `make format-codebase`: Runs all formatter targets (such as Prettier) to
   format files in the repository.
@@ -57,6 +61,14 @@ the most important targets:
 
   ```bash
   make format-prettier FILES_TO_FORMAT="test/linters/html/html_good_01.html"
+  ```
+
+- `make format-shfmt`: Runs `shfmt` to format shell scripts in the codebase. You
+  can format specific files or directories in isolation by passing the
+  `FILES_TO_FORMAT` variable:
+
+  ```bash
+  make format-shfmt FILES_TO_FORMAT="scripts/manage-vulnerability-issues.sh"
   ```
 
 - `make test`: Runs the complete test suite. The full test suite runs complex


### PR DESCRIPTION
- Move security audit to a dedicated GitHub Actions workflow
- Don't block the CD workflow, but still run audits
- Implement a target to format shell scripts

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
