### PR TITLE
chore: linter version format test

### DIFF
--- a/test/lib/linterVersionsTest.sh
+++ b/test/lib/linterVersionsTest.sh
@@ -58,5 +58,53 @@ VersionsFileCompletenessTest() {
   notice "${FUNCTION_NAME} PASS"
 }
 
+VersionsFileFormatTest() {
+  local FUNCTION_NAME
+  FUNCTION_NAME="${FUNCNAME[0]}"
+  info "${FUNCTION_NAME} start"
+
+  local LINE_NUMBER=0
+  local FAILED=false
+
+  while IFS= read -r LINE; do
+    LINE_NUMBER=$((LINE_NUMBER + 1))
+    if [[ -z "${LINE}" ]]; then
+      continue
+    fi
+
+    if [[ "${LINE}" =~ ^\[(.*?)\]\ (.*?):\ (.*)$ ]]; then
+      local LANGUAGE="${BASH_REMATCH[1]}"
+      local LINTER="${BASH_REMATCH[2]}"
+      local VERSION_STRING="${BASH_REMATCH[3]}"
+
+      if [[ "${VERSION_STRING}" == "Version command not supported" ]]; then
+        continue
+      fi
+
+      # Check for unexpected whitespace
+      if [[ "${VERSION_STRING}" =~ [[:space:]] ]]; then
+        error "Version string contains whitespace in line ${LINE_NUMBER} for ${LANGUAGE} (${LINTER}): '${VERSION_STRING}'"
+        FAILED=true
+      fi
+
+      # Check for SemVer-like (X.Y) OR 4+ digit build number (like xmllint's 21309)
+      if [[ ! "${VERSION_STRING}" =~ ([0-9]+\.[0-9]+)|([0-9]{4,}) ]]; then
+        error "Invalid version format in line ${LINE_NUMBER} for ${LANGUAGE} (${LINTER}): '${VERSION_STRING}'"
+        FAILED=true
+      fi
+    else
+      error "Invalid line format in line ${LINE_NUMBER}: '${LINE}'"
+      FAILED=true
+    fi
+  done <"${VERSION_FILE}"
+
+  if [[ "${FAILED}" == "true" ]]; then
+    fatal "One or more version strings are not well formatted"
+  fi
+
+  notice "${FUNCTION_NAME} PASS"
+}
+
 VersionsFileSortTest
 VersionsFileCompletenessTest
+VersionsFileFormatTest


### PR DESCRIPTION
Implement a test to check if each entry of the versions file is either a version string or a string that contains a build date (for xmllint).

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
