### PR TITLE
fix(output): pass comment payload via stdin to jq and curl

### DIFF
--- a/lib/functions/output.sh
+++ b/lib/functions/output.sh
@@ -160,11 +160,11 @@ CallGitHubApi() {
   fi
 
   if [[ -n "${PAYLOAD}" ]]; then
-    CURL_ARGS+=(-d "${PAYLOAD}")
+    CURL_ARGS+=(-d @-)
   fi
 
   local CALL_GITHUB_API_OUT
-  if ! CALL_GITHUB_API_OUT=$(curl "${CURL_ARGS[@]}" 2>&1); then
+  if ! CALL_GITHUB_API_OUT=$(printf '%s' "${PAYLOAD:-}" | curl "${CURL_ARGS[@]}" 2>&1); then
     error "Failed to call GitHub API (${GITHUB_URL}) with ${HTTP_METHOD} HTTP method: ${CALL_GITHUB_API_OUT}"
     return 1
   fi
@@ -203,13 +203,21 @@ CreateGitHubCommitStatus() {
   fi
 }
 
+GenerateIssueCommentPayload() {
+  local COMMENT_PAYLOAD="${1}"
+  if ! printf '%s' "${COMMENT_PAYLOAD}" | jq -R -s '{body: .} ' 2>&1; then
+    error "Error while generating payload comment."
+    return 1
+  fi
+}
+
 # Ref: https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#create-an-issue-comment
 CreateGitHubIssueComment() {
   local COMMENT_PAYLOAD="${1}" && shift
   local GITHUB_ISSUE_NUMBER="${1}" && shift
 
   local CREATE_ISSUE_COMMENT_API_PAYLOAD
-  if ! CREATE_ISSUE_COMMENT_API_PAYLOAD="$(jq --null-input --arg body "${COMMENT_PAYLOAD}" '{body: $body}')"; then
+  if ! CREATE_ISSUE_COMMENT_API_PAYLOAD="$(GenerateIssueCommentPayload "${COMMENT_PAYLOAD}")"; then
     warn "Error while loading the contents of COMMENT_PAYLOAD to CREATE_ISSUE_COMMENT_API_PAYLOAD"
     return 1
   fi
@@ -308,7 +316,7 @@ UpdateGitHubIssueComment() {
   local COMMENT_ID="${1}" && shift
 
   local UPDATE_ISSUE_COMMENT_API_PAYLOAD
-  if ! UPDATE_ISSUE_COMMENT_API_PAYLOAD="$(jq --null-input --arg body "${COMMENT_PAYLOAD}" '{body: $body}' 2>&1)"; then
+  if ! UPDATE_ISSUE_COMMENT_API_PAYLOAD="$(GenerateIssueCommentPayload "${COMMENT_PAYLOAD}" 2>&1)"; then
     warn "Error while loading the contents of COMMENT_PAYLOAD to UPDATE_ISSUE_COMMENT_API_PAYLOAD: ${UPDATE_ISSUE_COMMENT_API_PAYLOAD}"
     return 1
   fi

--- a/test/lib/outputTest.sh
+++ b/test/lib/outputTest.sh
@@ -319,6 +319,65 @@ RemoveAnsiColorCodesFromFileTest() {
   notice "${FUNCTION_NAME} PASS"
 }
 
+GenerateIssueCommentPayloadLargeInputTest() {
+  local FUNCTION_NAME="${FUNCNAME[0]}"
+  info "${FUNCTION_NAME} start"
+
+  local LARGE_INPUT
+  LARGE_INPUT="$(printf 'a%.0s' {1..200000})"
+
+  local PAYLOAD
+  if ! PAYLOAD="$(GenerateIssueCommentPayload "${LARGE_INPUT}")"; then
+    fatal "GenerateIssueCommentPayload failed with large input"
+  fi
+
+  if ! echo "${PAYLOAD}" | jq -e . >/dev/null; then
+    fatal "GenerateIssueCommentPayload produced invalid JSON"
+  fi
+
+  local PARSED_BODY
+  PARSED_BODY="$(echo "${PAYLOAD}" | jq -r .body)"
+  if [[ "${PARSED_BODY}" != "${LARGE_INPUT}" ]]; then
+    fatal "Parsed body doesn't match input"
+  fi
+
+  notice "${FUNCTION_NAME} PASS"
+}
+
+CallGitHubApiLargePayloadTest() {
+  local FUNCTION_NAME="${FUNCNAME[0]}"
+  info "${FUNCTION_NAME} start"
+
+  local LARGE_INPUT
+  LARGE_INPUT="$(printf 'a%.0s' {1..200000})"
+
+  curl() {
+    echo "MOCKED_CURL_CALLED"
+    echo "ARGS: $*"
+    echo "STDIN: $(cat)"
+    return 0
+  }
+
+  local GITHUB_API_OUT
+  if ! GITHUB_API_OUT="$(CallGitHubApi "http://fake-url" "fake-token" "${LARGE_INPUT}" "POST")"; then
+    fatal "Error while calling the GitHub API: ${GITHUB_API_OUT}"
+  fi
+
+  if [[ "${GITHUB_API_OUT}" != *"MOCKED_CURL_CALLED"* ]]; then
+    fatal "curl was not called. Output: ${GITHUB_API_OUT}"
+  fi
+
+  if [[ "${GITHUB_API_OUT}" != *"-d @-"* ]]; then
+    fatal "curl was not called with -d @-. Output: ${GITHUB_API_OUT}"
+  fi
+
+  if [[ "${GITHUB_API_OUT}" != *"${LARGE_INPUT}"* ]]; then
+    fatal "curl did not receive the expected payload via stdin"
+  fi
+
+  notice "${FUNCTION_NAME} PASS"
+}
+
 WriteSummaryMarkdownTableHeaderTest
 WriteMarkdownCodeBlockTest
 WriteSummaryMarkdownTableLineSuccessTest
@@ -331,3 +390,5 @@ WriteSummaryMarkdownTableFooterMoreInfoLogTest
 WriteSummaryFooterSuperLinterInfoTest
 WriteMarkdownCollapsedSectionTest
 RemoveAnsiColorCodesFromFileTest
+GenerateIssueCommentPayloadLargeInputTest
+CallGitHubApiLargePayloadTest


### PR DESCRIPTION
Avoid Argument list too long errors when posting or updating large pull request summary comments by passing the payload via standard input instead of command-line arguments to jq and curl.

<!-- Start with an H2 because GitHub automatically adds the commit description before the template, -->
<!-- so contributors don't have to manually cut-paste the description after the H1. -->
<!-- Also, include the header in a "prettier ignore" block because it adds a blank line -->
<!-- after the markdownlint-disable-next-line directive, making it useless. -->
<!-- Ref: https://github.com/prettier/prettier/issues/14350 -->
<!-- Ref: https://github.com/prettier/prettier/issues/10128 -->
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.
