### PR TITLE
deps(all): add dependency cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 100
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     commit-message:
@@ -30,6 +32,8 @@ updates:
           - docker/*
           - googleapis/*
           - peter-evans/create-issue-from-file
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     commit-message:
@@ -72,6 +76,8 @@ updates:
           - prettier
           - renovate
           - typescript
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "bundler"
     commit-message:
@@ -89,6 +95,8 @@ updates:
         applies-to: version-updates
         patterns:
           - "rubocop*"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "docker"
     commit-message:
@@ -138,6 +146,8 @@ updates:
           # dependencies in the case of wheel not being available for more
           # recent Python version
           - python
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     commit-message:
@@ -174,6 +184,8 @@ updates:
           - sqlfluff
           - yamllint
           - zizmor
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "gradle"
     commit-message:
@@ -198,6 +210,8 @@ updates:
           - "com.google.googlejavaformat:google-java-format"
           - "com.pinterest.ktlint:ktlint-cli"
           - "com.puppycrawl.tools:checkstyle"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "docker"
     commit-message:
@@ -215,6 +229,8 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     commit-message:
@@ -233,6 +249,8 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "composer"
     commit-message:
@@ -253,3 +271,5 @@ updates:
           - squizlabs/php_codesniffer
           - phpstan/phpstan
           - vimeo/psalm
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Add a 7-day dependency cooldown for all Dependabot package ecosystems. This means that Dependabot will only generate PRs for an update after a 7-day delay from when it was released. Dependency cooldowns are a simple, effective way to mitigate many supply-chain attacks: https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html

In order to have this pull request merged, complete the following tasks.

### Pull request author tasks

- [x] I checked that all workflows return a success.
- [x] I included all the needed documentation for this change.
- [x] I provided the necessary tests.
- [x] I squashed all the commits into a single commit.
- [x] I followed the
      [Conventional Commit v1.0.0 spec](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I wrote the necessary upgrade instructions in the
      [upgrade guide](https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md).
- [x] If this pull request is about and existing issue, I added the
      `Fix #ISSUE_NUMBER` or `Close #ISSUE_NUMBER` text to the description of
      the pull request.

### Super-linter maintainer tasks

- [x] Label as `breaking` if this change breaks compatibility with the previous
      released version.
- [x] Label as either: `automation`, `bug`, `documentation`, `enhancement`,
      `infrastructure`.
- [x] Add the pull request to a milestone, eventually creating one, that matches
      with the version that release-please proposes in the
      `preview-release-notes` CI job.