### PR TITLE
fix(codespell): skip root package lockfiles

### DIFF
--- a/.github/linters/.codespellrc
+++ b/.github/linters/.codespellrc
@@ -3,4 +3,4 @@
 ; https://github.com/codespell-project/codespell/issues/3854 is resolved
 ; check-filenames =
 check-hidden =
-skip = */package-lock.json,*.log,super-linter-output,.git
+skip = package-lock.json,*/package-lock.json,*.log,super-linter-output,.git

--- a/TEMPLATES/.codespellrc
+++ b/TEMPLATES/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 check-hidden =
-skip = */package-lock.json,*/go.mod,*/go.sum,*.log,.git
+skip = package-lock.json,*/package-lock.json,*/go.mod,*/go.sum,*.log,.git

--- a/test/lib/linterRulesTest.sh
+++ b/test/lib/linterRulesTest.sh
@@ -139,6 +139,30 @@ function LinterRulesVariablesExportTest() {
   notice "${FUNCTION_NAME} PASS"
 }
 
+function CodespellDefaultConfigurationSkipsPackageLockFilesTest() {
+  local FUNCTION_NAME
+  FUNCTION_NAME="${FUNCNAME[0]}"
+  info "${FUNCTION_NAME} start"
+
+  local TEST_DIRECTORY
+  TEST_DIRECTORY="$(mktemp -d)"
+  initialize_temp_directory_cleanup_traps "${TEST_DIRECTORY}"
+  mkdir -p "${TEST_DIRECTORY}/nested"
+  printf '{"description":"t%sh"}\n' "e" >"${TEST_DIRECTORY}/package-lock.json"
+  printf '{"description":"t%sh"}\n' "e" >"${TEST_DIRECTORY}/nested/package-lock.json"
+
+  local CODESPELL_DEFAULT_CONFIGURATION
+  CODESPELL_DEFAULT_CONFIGURATION="$(realpath "TEMPLATES/.codespellrc")"
+  if ! (
+    cd "${TEST_DIRECTORY}"
+    codespell --config "${CODESPELL_DEFAULT_CONFIGURATION}" package-lock.json nested/package-lock.json
+  ); then
+    fatal "The default codespell configuration should skip package-lock.json files at the workspace root and in nested directories"
+  fi
+
+  notice "${FUNCTION_NAME} PASS"
+}
+
 LoadDefaultRulesTest() {
   local FUNCTION_NAME
   FUNCTION_NAME="${FUNCNAME[0]}"
@@ -160,4 +184,5 @@ GetLinterRulesTest
 GetLinterRulesEmptyDotRulesPathTest
 GetLinterRulesEmptyRootRulesPathTest
 LinterRulesVariablesExportTest
+CodespellDefaultConfigurationSkipsPackageLockFilesTest
 LoadDefaultRulesTest


### PR DESCRIPTION
Fixes #8082

## What

- Add an exact `package-lock.json` skip pattern while retaining the existing nested-path pattern in the default and repository codespell configurations.
- Add a regression in `test/lib/linterRulesTest.sh` that exercises both root and nested lockfiles.
- Register the regression's temporary directory with the repository cleanup trap, as requested in review.

## Why

When Super-linter passes a root lockfile to codespell as `package-lock.json`, the existing `*/package-lock.json` pattern does not match because the argument has no directory separator. Nested lockfiles are already covered, so both forms are needed.

## Verification

Fresh on the branch rebased onto current `main` (`2066911`):

- repository-pinned codespell 2.4.3: root and nested lockfiles exit 0; a non-lockfile control containing the same misspelling exits 65
- `bash -n test/lib/linterRulesTest.sh`: passed
- shfmt 3.13.1 on `test/lib/linterRulesTest.sh`: passed
- ShellCheck 0.11.0 on `test/lib/linterRulesTest.sh`: passed
- `git diff --check`: passed

## Validation boundary

Docker is not available in the local Windows environment. The complete `linterRulesTest.sh`/`make test` path depends on the project container and `/action/lib/.automation`, so the full container suite remains for PR CI. I have not marked that suite as locally passed.

## Readiness checklist

- [ ] I checked that all workflows return a success. (Waiting for PR CI.)
- [x] No user-facing documentation change is needed for this default-configuration correction.
- [x] I provided the necessary regression test.
- [x] I squashed the change into a single commit.
- [x] I followed the Conventional Commits v1.0.0 specification.
- [x] No upgrade-guide entry is needed because this is a backwards-compatible bug fix.
- [x] The pull request links and closes the existing issue.

## AI-assisted disclosure

I used an AI coding assistant to help inspect the configuration path, draft the focused patch and test, and review the final diff. I reproduced the bug with the pinned codespell version, ran every check listed above, addressed the maintainer's review comments, and reviewed the submitted changes and public text before updating this pull request.